### PR TITLE
docs: expand README usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,203 @@
 [![GitHub Release][releases-shield]][releases]
 [![GitHub Activity][commits-shield]][commits]
+[![Coverage][coverage-shield]][coverage]
 [![License][license-shield]](LICENSE)
 
 ![Project Maintenance][maintenance-shield]
 [![BuyMeCoffee][buymecoffeebadge]][buymecoffee]
 
+[![PyPI][pypi-logo]][pypi]
 
-Api Wrapper for Carrier Infinity API using async in python, this was inspired by [this guide](https://developers.home-assistant.io/docs/api_lib_index) to be a lightweight wrapper, with simple error handling.
+# carrier_api
 
-a lot of this is based on https://my.carrier.com/.
+Async Python client for Carrier Infinity and Bryant Evolution HVAC systems.
 
-***
+This package wraps the Carrier Infinity GraphQL API, exposes typed model objects for system profile, status, configuration, and energy data, and includes helper methods for common thermostat updates. It is intended for integrations and local automation code that need a lightweight API client rather than a full
+application.
 
-[carrier_api]: https://github.com/dahlb/carrier_api
-[commits-shield]: https://img.shields.io/github/commit-activity/y/dahlb/carrier_api.svg?style=for-the-badge
-[commits]: https://github.com/dahlb/carrier_api/commits/main
-[forum]: https://community.home-assistant.io/
-[license-shield]: https://img.shields.io/github/license/dahlb/carrier_api.svg?style=for-the-badge
-[maintenance-shield]: https://img.shields.io/badge/maintainer-Bren%20Dahl%20%40dahlb-blue.svg?style=for-the-badge
-[releases-shield]: https://img.shields.io/github/release/dahlb/carrier_api.svg?style=for-the-badge
-[releases]: https://github.com/dahlb/carrier_api/releases
-[buymecoffee]: https://www.buymeacoffee.com/dahlb
-[buymecoffeebadge]: https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg?style=for-the-badge
+The client is unofficial and depends on Carrier's private web and mobile API behavior. Carrier can change that API without notice.
 
+## Requirements
 
-to update schema add this to api_connection_graphql#authed_query
+- Python 3.14 or newer
+- A Carrier or Bryant account that works in the official app
+- Network access to Carrier's cloud API
+
+## Installation
+
+Install the published package in a virtual environment:
+
+```bash
+python3.14 -m venv .venv
+.venv/bin/python -m pip install carrier_api
 ```
+
+## Live Smoke Test
+
+The live smoke test connects to a real Carrier account, prints loaded system state, starts websocket listeners, and sends one sample manual activity update to the first available zone.
+
+```bash
+scripts/live_smoke_test
+```
+
+Use it only when you want to exercise the live Carrier API. It can change thermostat settings.
+
+## Basic Usage
+
+```python
+import asyncio
+
+from carrier_api import ApiConnectionGraphql
+
+
+async def main() -> None:
+    api = ApiConnectionGraphql(
+        username="your-account@example.com",
+        password="your-password",
+    )
+    try:
+        systems = await api.load_data()
+        for system in systems:
+            print(system.profile.name)
+            print(system.status.mode)
+            print(system.as_dict())
+    finally:
+        await api.cleanup()
+
+
+asyncio.run(main())
+```
+
+`load_data()` authenticates when needed and returns a list of `System` objects. Each `System` includes:
+
+- `profile`: system identity and location metadata
+- `status`: current mode, temperature, humidity, zone, and equipment state
+- `config`: configured zones, activities, schedules, and holds
+- `energy`: reported energy usage data
+
+Model objects provide `as_dict()` for structured serialization. Their string and repr forms are intended for readable debugging output.
+
+## Updating Thermostat Settings
+
+Mutation helpers send Carrier configuration updates and then request websocket reconciliation when a websocket manager is available.
+
+```python
+import asyncio
+
+from carrier_api import ActivityTypes, ApiConnectionGraphql, FanModes, SystemModes
+
+
+async def main() -> None:
+    api = ApiConnectionGraphql(
+        username="your-account@example.com",
+        password="your-password",
+    )
+    try:
+        systems = await api.load_data()
+        system = systems[0]
+        zone = system.config.zones[0]
+
+        await api.set_config_mode(system.profile.serial, SystemModes.AUTO)
+        await api.update_fan(
+            system_serial=system.profile.serial,
+            zone_id=zone.api_id,
+            activity_type=ActivityTypes.HOME,
+            fan_mode=FanModes.LOW,
+        )
+        await api.set_config_manual_activity(
+            system_serial=system.profile.serial,
+            zone_id=zone.api_id,
+            heat_set_point="68",
+            cool_set_point="74",
+            fan_mode=FanModes.LOW,
+        )
+    finally:
+        await api.cleanup()
+
+
+asyncio.run(main())
+```
+
+Available update helpers include:
+
+- `set_config_mode(...)`
+- `set_config_heat_humidity(...)`
+- `set_heat_source(...)`
+- `set_humidifier(...)`
+- `update_fan(...)`
+- `set_config_hold(...)`
+- `resume_schedule(...)`
+- `set_config_manual_activity(...)`
+
+These methods can change real HVAC settings. Validate the selected system, zone, mode, and set points before calling them from automation.
+
+## Realtime Updates
+
+`ApiWebsocket` manages Carrier realtime messages. `WebsocketDataUpdater` can merge incoming websocket messages into the `System` objects returned by `load_data()`.
+
+```python
+import asyncio
+
+from carrier_api import ApiConnectionGraphql, WebsocketDataUpdater
+
+
+async def main() -> None:
+    api = ApiConnectionGraphql(
+        username="your-account@example.com",
+        password="your-password",
+    )
+    try:
+        systems = await api.load_data()
+        updater = WebsocketDataUpdater(systems)
+
+        if api.api_websocket is None:
+            raise RuntimeError("websocket manager was not initialized")
+
+        api.api_websocket.callback_add(updater.message_handler)
+        await api.api_websocket.create_task_listener()
+    finally:
+        await api.cleanup()
+
+
+asyncio.run(main())
+```
+
+Callbacks receive the raw websocket message text. Register `WebsocketDataUpdater.message_handler` first when later callbacks need to read the updated in-memory system state.
+
+## Development
+
+Clone this repository and install the development environment:
+
+```bash
+git clone https://github.com/dahlb/carrier_api.git
+cd carrier_api
+scripts/setup
+```
+
+Use the repository scripts so commands run through the local `.venv`.
+
+```bash
+scripts/setup
+scripts/test
+scripts/lint
+```
+
+The underlying commands are:
+
+```bash
+./.venv/bin/pytest
+./.venv/bin/prek run --all-files
+./.venv/bin/mypy .
+```
+
+Add or update deterministic pytest coverage for behavior changes. Fixture data for GraphQL and websocket responses lives under `tests/graphql` and
+`tests/messages`.
+
+## Updating the Captured Schema
+
+To refresh `schema.graphql`, temporarily add this diagnostic block inside `ApiConnectionGraphql.authed_query()` after the GraphQL session is created:
+
+```python
 introspection_query = get_introspection_query(**session.client.introspection_args)
 execution_result = await transport.execute(parse(introspection_query))
 schema = dumps(execution_result.data, indent=2)
@@ -33,3 +205,24 @@ _LOGGER.debug(schema)
 with open("schema.graphql", "w") as f:
     f.write(schema)
 ```
+
+Keep one-off schema capture edits out of final commits unless the capture logic itself is being changed.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidance. Please open bugs and feature requests in the
+[issue tracker](https://github.com/dahlb/carrier_api/issues).
+
+[carrier_api]: https://github.com/dahlb/carrier_api
+[commits-shield]: https://img.shields.io/github/commit-activity/y/dahlb/carrier_api.svg?style=for-the-badge
+[commits]: https://github.com/dahlb/carrier_api/commits/main
+[license-shield]: https://img.shields.io/github/license/dahlb/carrier_api.svg?style=for-the-badge
+[maintenance-shield]: https://img.shields.io/badge/maintainer-Bren%20Dahl%20%40dahlb-blue.svg?style=for-the-badge
+[pypi-logo]: https://img.shields.io/badge/PyPI-3775A9?logo=pypi&logoColor=fff&style=for-the-badge
+[pypi]: https://pypi.org/project/carrier_api/
+[coverage]: https://htmlpreview.github.io/?https://github.com/dahlb/carrier_api/blob/python-coverage-comment-action-data/htmlcov/index.html
+[coverage-shield]: https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdahlb%2Fcarrier_api%2Fpython-coverage-comment-action-data%2Fendpoint.json&style=for-the-badge
+[releases-shield]: https://img.shields.io/github/release/dahlb/carrier_api.svg?style=for-the-badge
+[releases]: https://github.com/dahlb/carrier_api/releases
+[buymecoffee]: https://www.buymeacoffee.com/dahlb
+[buymecoffeebadge]: https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg?style=for-the-badge

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,0 @@
-old way
-python setup.py install
-twine upload dist/*
-
-
-new way
-python3 -m pip install --upgrade build
-python3 -m build
-python3 -m twine upload dist/*


### PR DESCRIPTION
## Summary
Expands the README from a placeholder into a practical user and developer guide for carrier_api. It documents installation, read-only usage, mutation helpers, websocket updates, development commands, and schema refresh notes.

## What Changed
- Added PyPI and coverage badges alongside the existing project badges.
- Replaced the short placeholder description with package purpose, requirements, installation, and live smoke-test cautions.
- Added examples for loading systems, serializing model state, updating thermostat settings, and wiring websocket updates.
- Documented local development commands and schema capture guidance.
- Removed the obsolete RELEASE.md notes in favor of the current README workflow guidance.

## Why
The previous README did not give users enough context to install, evaluate, or safely exercise the library. This makes the public package easier to adopt while warning that live mutation helpers can change real HVAC settings.