### PR TITLE
Normalize Carrier API errors

### DIFF
--- a/src/carrier_api/__init__.py
+++ b/src/carrier_api/__init__.py
@@ -10,9 +10,11 @@ from .errors import (
     AuthError,
     BaseError,
     CarrierApiAuthError,
+    CarrierApiConnectionError,
     CarrierApiError,
     CarrierApiGraphqlError,
     CarrierApiTokenRefreshError,
+    CarrierApiWebsocketError,
 )
 from .profile import Profile
 from .status import Status, StatusZone
@@ -25,9 +27,11 @@ __all__ = [
     "AuthError",
     "BaseError",
     "CarrierApiAuthError",
+    "CarrierApiConnectionError",
     "CarrierApiError",
     "CarrierApiGraphqlError",
     "CarrierApiTokenRefreshError",
+    "CarrierApiWebsocketError",
     "Config",
     "ConfigZone",
     "ConfigZoneActivity",

--- a/src/carrier_api/__init__.py
+++ b/src/carrier_api/__init__.py
@@ -6,7 +6,14 @@ from .api_websocket_data_updater import WebsocketDataUpdater
 from .config import Config, ConfigZone, ConfigZoneActivity
 from .const import ActivityTypes, FanModes, SystemModes, TemperatureUnits
 from .energy import Energy
-from .errors import AuthError, BaseError
+from .errors import (
+    AuthError,
+    BaseError,
+    CarrierApiAuthError,
+    CarrierApiError,
+    CarrierApiGraphqlError,
+    CarrierApiTokenRefreshError,
+)
 from .profile import Profile
 from .status import Status, StatusZone
 from .system import System
@@ -17,6 +24,10 @@ __all__ = [
     "ApiWebsocket",
     "AuthError",
     "BaseError",
+    "CarrierApiAuthError",
+    "CarrierApiError",
+    "CarrierApiGraphqlError",
+    "CarrierApiTokenRefreshError",
     "Config",
     "ConfigZone",
     "ConfigZoneActivity",

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -7,7 +7,11 @@ from typing import Any, Literal
 from aiohttp import ClientError, ClientResponseError, ClientSession
 from gql import Client, GraphQLRequest, gql
 from gql.transport.aiohttp import AIOHTTPTransport
-from gql.transport.exceptions import TransportError as GraphqlTransportError, TransportQueryError
+from gql.transport.exceptions import (
+    TransportError as GraphqlTransportError,
+    TransportQueryError,
+    TransportServerError,
+)
 from graphql import GraphQLError
 
 from .api_websocket import ApiWebsocket
@@ -29,6 +33,20 @@ GRAPHQL_EXECUTE_TIMEOUT_SECONDS = 60
 
 _GRAPHQL_ERRORS = (GraphqlTransportError, TransportQueryError, GraphQLError)
 _CONNECTION_ERRORS = (GraphqlTransportError, ClientError, TimeoutError, OSError)
+_AUTH_HTTP_STATUSES = {401, 403}
+
+
+def _is_auth_transport_error(error: BaseException) -> bool:
+    """Return whether a transport error represents Carrier auth rejection.
+
+    Args:
+        error: Exception raised by the GraphQL transport.
+
+    Returns:
+        ``True`` when the GraphQL endpoint rejected the request with an
+        authentication-related HTTP status.
+    """
+    return isinstance(error, TransportServerError) and error.code in _AUTH_HTTP_STATUSES
 
 
 class ApiConnectionGraphql:
@@ -199,6 +217,10 @@ class ApiConnectionGraphql:
                 f"Carrier GraphQL operation failed: {operation_name}"
             ) from error
         except _CONNECTION_ERRORS as error:
+            if _is_auth_transport_error(error):
+                raise CarrierApiAuthError(
+                    f"Carrier authorization failed during GraphQL operation: {operation_name}"
+                ) from error
             raise CarrierApiConnectionError(
                 f"Carrier connection failed during GraphQL operation: {operation_name}"
             ) from error

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -136,7 +136,10 @@ class ApiConnectionGraphql:
         """Refresh the OAuth access token using the stored refresh token.
 
         Raises:
-            CarrierApiTokenRefreshError: If Carrier rejects the refresh request.
+            CarrierApiAuthError: If Carrier rejects the refresh token as invalid
+                or unauthorized.
+            CarrierApiTokenRefreshError: If token refresh fails before Carrier
+                returns a valid OAuth response.
         """
         url = "https://sso.carrier.com/oauth2/default/v1/token"
         json_body = {
@@ -145,12 +148,15 @@ class ApiConnectionGraphql:
             "refresh_token": self.refresh_token,
             "scope": "offline_access",
         }
+        data: dict[str, Any] = {}
         try:
             response = await self.api_session.post(url=url, data=json_body)
-            response.raise_for_status()
             data = await response.json()
+            response.raise_for_status()
         except ClientResponseError as error:
-            if error.status in {401, 403}:
+            if error.status in {401, 403} or (
+                error.status == 400 and data.get("error") == "invalid_grant"
+            ):
                 raise CarrierApiAuthError("Carrier token refresh was rejected") from error
             raise CarrierApiTokenRefreshError("Carrier token refresh failed") from error
         except (ClientError, TimeoutError, OSError) as error:

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -199,10 +199,13 @@ class ApiConnectionGraphql:
             raise CarrierApiTokenRefreshError("Carrier token refresh failed") from error
         except (ClientError, TimeoutError, OSError, TypeError, ValueError) as error:
             raise CarrierApiTokenRefreshError("Carrier token refresh failed") from error
-        self.expires_at = datetime.now(UTC) + timedelta(seconds=data["expires_in"])
-        self.token_type = data["token_type"]
-        self.access_token = data["access_token"]
-        self.refresh_token = data["refresh_token"]
+        try:
+            self.expires_at = datetime.now(UTC) + timedelta(seconds=data["expires_in"])
+            self.token_type = data["token_type"]
+            self.access_token = data["access_token"]
+            self.refresh_token = data["refresh_token"]
+        except (KeyError, TypeError) as error:
+            raise CarrierApiTokenRefreshError("Carrier token refresh failed") from error
 
     async def authed_query(
         self, operation_name: str, query: GraphQLRequest, variable_values: dict[str, Any]

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 from logging import getLogger
 from typing import Any, Literal
 
-from aiohttp import ClientError, ClientSession
+from aiohttp import ClientError, ClientResponseError, ClientSession
 from gql import Client, GraphQLRequest, gql
 from gql.transport.aiohttp import AIOHTTPTransport
 from gql.transport.exceptions import TransportError as GraphqlTransportError, TransportQueryError
@@ -14,7 +14,12 @@ from .api_websocket import ApiWebsocket
 from .config import Config
 from .const import ActivityTypes, FanModes, HeatSourceTypes, SystemModes
 from .energy import Energy
-from .errors import CarrierApiAuthError, CarrierApiGraphqlError, CarrierApiTokenRefreshError
+from .errors import (
+    CarrierApiAuthError,
+    CarrierApiConnectionError,
+    CarrierApiGraphqlError,
+    CarrierApiTokenRefreshError,
+)
 from .profile import Profile
 from .status import Status
 from .system import System
@@ -23,6 +28,7 @@ _LOGGER = getLogger(__name__)
 GRAPHQL_EXECUTE_TIMEOUT_SECONDS = 60
 
 _GRAPHQL_ERRORS = (GraphqlTransportError, TransportQueryError, GraphQLError)
+_CONNECTION_ERRORS = (GraphqlTransportError, ClientError, TimeoutError, OSError)
 
 
 class ApiConnectionGraphql:
@@ -69,30 +75,30 @@ class ApiConnectionGraphql:
         transport = AIOHTTPTransport(
             url="https://dataservice.infinity.iot.carrier.com/graphql-no-auth", ssl=True
         )
-        async with Client(
-            transport=transport,
-            fetch_schema_from_transport=False,
-        ) as session:
-            query = gql(
-                """
-                mutation assistedLogin($input: AssistedLoginInput!) {
-                    assistedLogin(input: $input) {
-                        success
-                        status
-                        errorMessage
-                        data {
-                            token_type
-                            expires_in
-                            access_token
-                            scope
-                            refresh_token
+        try:
+            async with Client(
+                transport=transport,
+                fetch_schema_from_transport=False,
+            ) as session:
+                query = gql(
+                    """
+                    mutation assistedLogin($input: AssistedLoginInput!) {
+                        assistedLogin(input: $input) {
+                            success
+                            status
+                            errorMessage
+                            data {
+                                token_type
+                                expires_in
+                                access_token
+                                scope
+                                refresh_token
+                            }
                         }
                     }
-                }
-            """
-            )
+                """
+                )
 
-            try:
                 result = await session.execute(
                     query,
                     variable_values={
@@ -100,20 +106,24 @@ class ApiConnectionGraphql:
                     },
                     operation_name="assistedLogin",
                 )
-            except _GRAPHQL_ERRORS as error:
-                raise CarrierApiAuthError("Carrier authentication request failed") from error
-            success = result["assistedLogin"]["success"]
-            if success:
-                self.expires_at = datetime.now(UTC) + timedelta(
-                    seconds=result["assistedLogin"]["data"]["expires_in"]
-                )
-                self.token_type = result["assistedLogin"]["data"]["token_type"]
-                self.access_token = result["assistedLogin"]["data"]["access_token"]
-                self.refresh_token = result["assistedLogin"]["data"]["refresh_token"]
-                if self.api_websocket is None:
-                    self.api_websocket = ApiWebsocket(self)
-            else:
-                raise CarrierApiAuthError("Carrier authentication failed", payload=result)
+                success = result["assistedLogin"]["success"]
+                if success:
+                    self.expires_at = datetime.now(UTC) + timedelta(
+                        seconds=result["assistedLogin"]["data"]["expires_in"]
+                    )
+                    self.token_type = result["assistedLogin"]["data"]["token_type"]
+                    self.access_token = result["assistedLogin"]["data"]["access_token"]
+                    self.refresh_token = result["assistedLogin"]["data"]["refresh_token"]
+                    if self.api_websocket is None:
+                        self.api_websocket = ApiWebsocket(self)
+                else:
+                    raise CarrierApiAuthError("Carrier authentication failed", payload=result)
+        except TransportQueryError as error:
+            raise CarrierApiGraphqlError("Carrier authentication GraphQL request failed") from error
+        except _CONNECTION_ERRORS as error:
+            raise CarrierApiConnectionError("Carrier authentication connection failed") from error
+        except GraphQLError as error:
+            raise CarrierApiGraphqlError("Carrier authentication GraphQL request failed") from error
 
     async def check_auth_expiration(self) -> None:
         """Ensure the connection has a valid access token before API use."""
@@ -139,7 +149,11 @@ class ApiConnectionGraphql:
             response = await self.api_session.post(url=url, data=json_body)
             response.raise_for_status()
             data = await response.json()
-        except (ClientError, TimeoutError) as error:
+        except ClientResponseError as error:
+            if error.status in {401, 403}:
+                raise CarrierApiAuthError("Carrier token refresh was rejected") from error
+            raise CarrierApiTokenRefreshError("Carrier token refresh failed") from error
+        except (ClientError, TimeoutError, OSError) as error:
             raise CarrierApiTokenRefreshError("Carrier token refresh failed") from error
         self.expires_at = datetime.now(UTC) + timedelta(seconds=data["expires_in"])
         self.token_type = data["token_type"]
@@ -165,19 +179,27 @@ class ApiConnectionGraphql:
             headers={"Authorization": f"{self.token_type} {self.access_token}"},
             ssl=True,
         )
-        async with Client(
-            transport=transport,
-            fetch_schema_from_transport=False,
-            execute_timeout=GRAPHQL_EXECUTE_TIMEOUT_SECONDS,
-        ) as session:
-            try:
+        try:
+            async with Client(
+                transport=transport,
+                fetch_schema_from_transport=False,
+                execute_timeout=GRAPHQL_EXECUTE_TIMEOUT_SECONDS,
+            ) as session:
                 return await session.execute(
                     query, variable_values=variable_values, operation_name=operation_name
                 )
-            except _GRAPHQL_ERRORS as error:
-                raise CarrierApiGraphqlError(
-                    f"Carrier GraphQL operation failed: {operation_name}"
-                ) from error
+        except TransportQueryError as error:
+            raise CarrierApiGraphqlError(
+                f"Carrier GraphQL operation failed: {operation_name}"
+            ) from error
+        except _CONNECTION_ERRORS as error:
+            raise CarrierApiConnectionError(
+                f"Carrier connection failed during GraphQL operation: {operation_name}"
+            ) from error
+        except GraphQLError as error:
+            raise CarrierApiGraphqlError(
+                f"Carrier GraphQL operation failed: {operation_name}"
+            ) from error
 
     async def get_user_info(self) -> dict[str, Any]:
         """Fetch Carrier account profile, location, and device metadata.

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -117,7 +117,7 @@ class ApiConnectionGraphql:
                     if self.api_websocket is None:
                         self.api_websocket = ApiWebsocket(self)
                 else:
-                    raise CarrierApiAuthError("Carrier authentication failed", payload=result)
+                    raise CarrierApiAuthError(result, payload=result)
         except TransportQueryError as error:
             raise CarrierApiGraphqlError("Carrier authentication GraphQL request failed") from error
         except _CONNECTION_ERRORS as error:

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -49,6 +49,25 @@ def _is_auth_transport_error(error: BaseException) -> bool:
     return isinstance(error, TransportServerError) and error.code in _AUTH_HTTP_STATUSES
 
 
+async def _response_json_object(response: Any) -> dict[str, Any]:
+    """Read a JSON object response body when available.
+
+    Args:
+        response: aiohttp-like response object with an async ``json`` method.
+
+    Returns:
+        The decoded JSON object, or an empty object when the body is malformed
+        or is not a JSON object.
+    """
+    try:
+        data = await response.json()
+    except ClientError, TypeError, ValueError:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
 class ApiConnectionGraphql:
     """Async Carrier GraphQL API connection with token and websocket support."""
 
@@ -166,18 +185,19 @@ class ApiConnectionGraphql:
             "refresh_token": self.refresh_token,
             "scope": "offline_access",
         }
-        data: dict[str, Any] = {}
+        response: Any | None = None
         try:
             response = await self.api_session.post(url=url, data=json_body)
-            data = await response.json()
             response.raise_for_status()
+            data = await response.json()
         except ClientResponseError as error:
+            data = {} if response is None else await _response_json_object(response)
             if error.status in {401, 403} or (
                 error.status == 400 and data.get("error") == "invalid_grant"
             ):
                 raise CarrierApiAuthError("Carrier token refresh was rejected") from error
             raise CarrierApiTokenRefreshError("Carrier token refresh failed") from error
-        except (ClientError, TimeoutError, OSError) as error:
+        except (ClientError, TimeoutError, OSError, TypeError, ValueError) as error:
             raise CarrierApiTokenRefreshError("Carrier token refresh failed") from error
         self.expires_at = datetime.now(UTC) + timedelta(seconds=data["expires_in"])
         self.token_type = data["token_type"]

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -157,7 +157,12 @@ class ApiConnectionGraphql:
                     if self.api_websocket is None:
                         self.api_websocket = ApiWebsocket(self)
                 else:
-                    raise CarrierApiAuthError(result, payload=result)
+                    error_message = result["assistedLogin"].get("errorMessage")
+                    if isinstance(error_message, str) and error_message:
+                        message = f"Carrier assistedLogin failed: {error_message}"
+                    else:
+                        message = "Carrier assistedLogin failed"
+                    raise CarrierApiAuthError(message, payload=result)
         except TransportQueryError as error:
             raise CarrierApiGraphqlError("Carrier authentication GraphQL request failed") from error
         except _CONNECTION_ERRORS as error:

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -7,18 +7,22 @@ from typing import Any, Literal
 from aiohttp import ClientSession
 from gql import Client, GraphQLRequest, gql
 from gql.transport.aiohttp import AIOHTTPTransport
+from gql.transport.exceptions import TransportError as GraphqlTransportError
+from graphql import GraphQLError
 
 from .api_websocket import ApiWebsocket
 from .config import Config
 from .const import ActivityTypes, FanModes, HeatSourceTypes, SystemModes
 from .energy import Energy
-from .errors import AuthError
+from .errors import AuthError, BaseError
 from .profile import Profile
 from .status import Status
 from .system import System
 
 _LOGGER = getLogger(__name__)
 GRAPHQL_EXECUTE_TIMEOUT_SECONDS = 60
+
+_GRAPHQL_ERRORS = (GraphqlTransportError, GraphQLError)
 
 
 class ApiConnectionGraphql:
@@ -88,11 +92,16 @@ class ApiConnectionGraphql:
             """
             )
 
-            result = await session.execute(
-                query,
-                variable_values={"input": {"password": self.password, "username": self.username}},
-                operation_name="assistedLogin",
-            )
+            try:
+                result = await session.execute(
+                    query,
+                    variable_values={
+                        "input": {"password": self.password, "username": self.username}
+                    },
+                    operation_name="assistedLogin",
+                )
+            except _GRAPHQL_ERRORS as error:
+                raise AuthError("Carrier authentication request failed") from error
             success = result["assistedLogin"]["success"]
             if success:
                 self.expires_at = datetime.now(UTC) + timedelta(
@@ -104,7 +113,7 @@ class ApiConnectionGraphql:
                 if self.api_websocket is None:
                     self.api_websocket = ApiWebsocket(self)
             else:
-                raise AuthError(result)
+                raise AuthError("Carrier authentication failed", payload=result)
 
     async def check_auth_expiration(self) -> None:
         """Ensure the connection has a valid access token before API use."""
@@ -158,9 +167,12 @@ class ApiConnectionGraphql:
             fetch_schema_from_transport=False,
             execute_timeout=GRAPHQL_EXECUTE_TIMEOUT_SECONDS,
         ) as session:
-            return await session.execute(
-                query, variable_values=variable_values, operation_name=operation_name
-            )
+            try:
+                return await session.execute(
+                    query, variable_values=variable_values, operation_name=operation_name
+                )
+            except _GRAPHQL_ERRORS as error:
+                raise BaseError(f"Carrier GraphQL operation failed: {operation_name}") from error
 
     async def get_user_info(self) -> dict[str, Any]:
         """Fetch Carrier account profile, location, and device metadata.

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 from logging import getLogger
 from typing import Any, Literal
 
-from aiohttp import ClientSession
+from aiohttp import ClientError, ClientSession
 from gql import Client, GraphQLRequest, gql
 from gql.transport.aiohttp import AIOHTTPTransport
 from gql.transport.exceptions import TransportError as GraphqlTransportError
@@ -14,7 +14,7 @@ from .api_websocket import ApiWebsocket
 from .config import Config
 from .const import ActivityTypes, FanModes, HeatSourceTypes, SystemModes
 from .energy import Energy
-from .errors import AuthError, BaseError
+from .errors import CarrierApiAuthError, CarrierApiGraphqlError, CarrierApiTokenRefreshError
 from .profile import Profile
 from .status import Status
 from .system import System
@@ -63,7 +63,7 @@ class ApiConnectionGraphql:
         """Authenticate with Carrier and initialize websocket support.
 
         Raises:
-            AuthError: If the assisted login mutation reports an unsuccessful
+            CarrierApiAuthError: If the assisted login mutation reports an unsuccessful
                 authentication result.
         """
         transport = AIOHTTPTransport(
@@ -101,7 +101,7 @@ class ApiConnectionGraphql:
                     operation_name="assistedLogin",
                 )
             except _GRAPHQL_ERRORS as error:
-                raise AuthError("Carrier authentication request failed") from error
+                raise CarrierApiAuthError("Carrier authentication request failed") from error
             success = result["assistedLogin"]["success"]
             if success:
                 self.expires_at = datetime.now(UTC) + timedelta(
@@ -113,7 +113,7 @@ class ApiConnectionGraphql:
                 if self.api_websocket is None:
                     self.api_websocket = ApiWebsocket(self)
             else:
-                raise AuthError("Carrier authentication failed", payload=result)
+                raise CarrierApiAuthError("Carrier authentication failed", payload=result)
 
     async def check_auth_expiration(self) -> None:
         """Ensure the connection has a valid access token before API use."""
@@ -126,7 +126,7 @@ class ApiConnectionGraphql:
         """Refresh the OAuth access token using the stored refresh token.
 
         Raises:
-            aiohttp.ClientResponseError: If Carrier rejects the refresh request.
+            CarrierApiTokenRefreshError: If Carrier rejects the refresh request.
         """
         url = "https://sso.carrier.com/oauth2/default/v1/token"
         json_body = {
@@ -135,9 +135,12 @@ class ApiConnectionGraphql:
             "refresh_token": self.refresh_token,
             "scope": "offline_access",
         }
-        response = await self.api_session.post(url=url, data=json_body)
-        response.raise_for_status()
-        data = await response.json()
+        try:
+            response = await self.api_session.post(url=url, data=json_body)
+            response.raise_for_status()
+            data = await response.json()
+        except (ClientError, TimeoutError) as error:
+            raise CarrierApiTokenRefreshError("Carrier token refresh failed") from error
         self.expires_at = datetime.now(UTC) + timedelta(seconds=data["expires_in"])
         self.token_type = data["token_type"]
         self.access_token = data["access_token"]
@@ -172,7 +175,9 @@ class ApiConnectionGraphql:
                     query, variable_values=variable_values, operation_name=operation_name
                 )
             except _GRAPHQL_ERRORS as error:
-                raise BaseError(f"Carrier GraphQL operation failed: {operation_name}") from error
+                raise CarrierApiGraphqlError(
+                    f"Carrier GraphQL operation failed: {operation_name}"
+                ) from error
 
     async def get_user_info(self) -> dict[str, Any]:
         """Fetch Carrier account profile, location, and device metadata.

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -61,7 +61,7 @@ async def _response_json_object(response: Any) -> dict[str, Any]:
     """
     try:
         data = await response.json()
-    except ClientError, TypeError, ValueError:
+    except ClientError, TimeoutError, OSError, TypeError, ValueError:
         return {}
     if not isinstance(data, dict):
         return {}
@@ -100,7 +100,10 @@ class ApiConnectionGraphql:
 
     async def cleanup(self) -> None:
         """Close the underlying aiohttp session owned by the connection."""
-        await self.api_session.close()
+        try:
+            await self.api_session.close()
+        except (ClientError, TimeoutError, OSError) as error:
+            raise CarrierApiConnectionError("Carrier API session cleanup failed") from error
 
     async def login(self) -> None:
         """Authenticate with Carrier and initialize websocket support.

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 from aiohttp import ClientError, ClientSession
 from gql import Client, GraphQLRequest, gql
 from gql.transport.aiohttp import AIOHTTPTransport
-from gql.transport.exceptions import TransportError as GraphqlTransportError
+from gql.transport.exceptions import TransportError as GraphqlTransportError, TransportQueryError
 from graphql import GraphQLError
 
 from .api_websocket import ApiWebsocket
@@ -22,7 +22,7 @@ from .system import System
 _LOGGER = getLogger(__name__)
 GRAPHQL_EXECUTE_TIMEOUT_SECONDS = 60
 
-_GRAPHQL_ERRORS = (GraphqlTransportError, GraphQLError)
+_GRAPHQL_ERRORS = (GraphqlTransportError, TransportQueryError, GraphQLError)
 
 
 class ApiConnectionGraphql:

--- a/src/carrier_api/api_websocket.py
+++ b/src/carrier_api/api_websocket.py
@@ -8,7 +8,9 @@ from logging import getLogger
 from random import random
 from typing import TYPE_CHECKING
 
-from aiohttp import ClientWebSocketResponse, WSMsgType
+from aiohttp import ClientError, ClientWebSocketResponse, WSMsgType
+
+from .errors import CarrierApiWebsocketError
 
 if TYPE_CHECKING:
     from .api_connection_graphql import ApiConnectionGraphql
@@ -94,22 +96,27 @@ class ApiWebsocket:
         state when the socket closes.
         """
         await self.api_connection_graphql.check_auth_expiration()
-        async with self.api_connection_graphql.api_session.ws_connect(
-            f"wss://realtime.infinity.iot.carrier.com/?Token={self.api_connection_graphql.access_token}"
-        ) as self.websocket:
-            if self.task_heartbeat is None:
-                await self.create_task_heartbeat()
-            if self.websocket is not None:
-                async for msg in self.websocket:
-                    if msg.type == WSMsgType.TEXT:
-                        if msg.data == "close cmd":
-                            await self.websocket.close()
+        try:
+            async with self.api_connection_graphql.api_session.ws_connect(
+                "wss://realtime.infinity.iot.carrier.com/"
+                f"?Token={self.api_connection_graphql.access_token}"
+            ) as self.websocket:
+                if self.task_heartbeat is None:
+                    await self.create_task_heartbeat()
+                if self.websocket is not None:
+                    async for msg in self.websocket:
+                        if msg.type == WSMsgType.TEXT:
+                            if msg.data == "close cmd":
+                                await self.websocket.close()
+                                break
+                            for async_callback in self.async_callbacks:
+                                await async_callback(msg.data)
+                        elif msg.type == WSMsgType.ERROR:
                             break
-                        for async_callback in self.async_callbacks:
-                            await async_callback(msg.data)
-                    elif msg.type == WSMsgType.ERROR:
-                        break
-            _LOGGER.debug("ws: closed")
+                _LOGGER.debug("ws: closed")
+        except (ClientError, TimeoutError, OSError) as error:
+            raise CarrierApiWebsocketError("Carrier websocket connection failed") from error
+        finally:
             self.websocket = None
             if self.task_heartbeat is not None:
                 self.task_heartbeat.cancel()

--- a/src/carrier_api/api_websocket.py
+++ b/src/carrier_api/api_websocket.py
@@ -129,10 +129,19 @@ class ApiWebsocket:
                                 except (ClientError, TimeoutError, OSError) as error:
                                     raise _CallbackError(error) from error
                         elif msg.type == WSMsgType.ERROR:
-                            break
+                            websocket_error = self.websocket.exception()
+                            if websocket_error is None:
+                                raise CarrierApiWebsocketError(
+                                    "Carrier websocket connection failed"
+                                )
+                            raise CarrierApiWebsocketError(
+                                "Carrier websocket connection failed"
+                            ) from websocket_error
                 _LOGGER.debug("ws: closed")
         except _CallbackError as error:
             raise error.error from None
+        except CarrierApiWebsocketError:
+            raise
         except (ClientError, TimeoutError, OSError) as error:
             raise CarrierApiWebsocketError("Carrier websocket connection failed") from error
         finally:

--- a/src/carrier_api/api_websocket.py
+++ b/src/carrier_api/api_websocket.py
@@ -20,6 +20,20 @@ _LOGGER = getLogger(__name__)
 AsyncCallback = Callable[[str], Awaitable[None]]
 
 
+class _CallbackError(Exception):
+    """Internal wrapper used to avoid treating callback I/O as websocket I/O."""
+
+    def __init__(self, error: ClientError | TimeoutError | OSError) -> None:
+        """Initialize the callback error wrapper.
+
+        Args:
+            error: Original callback exception to re-raise outside websocket
+                transport normalization.
+        """
+        super().__init__(str(error))
+        self.error = error
+
+
 class ApiWebsocket:
     """Manage Carrier realtime websocket connection state and callbacks."""
 
@@ -110,10 +124,15 @@ class ApiWebsocket:
                                 await self.websocket.close()
                                 break
                             for async_callback in self.async_callbacks:
-                                await async_callback(msg.data)
+                                try:
+                                    await async_callback(msg.data)
+                                except (ClientError, TimeoutError, OSError) as error:
+                                    raise _CallbackError(error) from error
                         elif msg.type == WSMsgType.ERROR:
                             break
                 _LOGGER.debug("ws: closed")
+        except _CallbackError as error:
+            raise error.error from None
         except (ClientError, TimeoutError, OSError) as error:
             raise CarrierApiWebsocketError("Carrier websocket connection failed") from error
         finally:

--- a/src/carrier_api/errors.py
+++ b/src/carrier_api/errors.py
@@ -39,6 +39,8 @@ class CarrierApiWebsocketError(CarrierApiConnectionError):
     """Raised when Carrier realtime websocket communication fails."""
 
 
-# Deprecated compatibility aliases. These will be removed in a future release.
+# Deprecated compatibility aliases. These preserve old import names but are not
+# parent classes for the new CarrierApi* hierarchy, so removing them later will
+# not require changing the inheritance of the supported exception classes.
 BaseError = CarrierApiError
 AuthError = CarrierApiAuthError

--- a/src/carrier_api/errors.py
+++ b/src/carrier_api/errors.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 
-class BaseError(Exception):
+class CarrierApiError(Exception):
     """Base exception for Carrier API failures."""
 
     def __init__(self, message: object, payload: Any | None = None) -> None:
@@ -17,5 +17,18 @@ class BaseError(Exception):
         self.payload = payload
 
 
-class AuthError(BaseError):
+class CarrierApiAuthError(CarrierApiError):
     """Raised when Carrier authentication fails or returns an unsuccessful result."""
+
+
+class CarrierApiGraphqlError(CarrierApiError):
+    """Raised when an authenticated Carrier GraphQL operation fails."""
+
+
+class CarrierApiTokenRefreshError(CarrierApiAuthError):
+    """Raised when Carrier access token refresh fails."""
+
+
+# Deprecated compatibility aliases. These will be removed in a future release.
+BaseError = CarrierApiError
+AuthError = CarrierApiAuthError

--- a/src/carrier_api/errors.py
+++ b/src/carrier_api/errors.py
@@ -1,11 +1,21 @@
 """Carrier API exception types."""
 
-from graphql import GraphQLError
+from typing import Any
 
 
-class BaseError(GraphQLError):
-    """Base GraphQL-compatible exception for Carrier API failures."""
+class BaseError(Exception):
+    """Base exception for Carrier API failures."""
+
+    def __init__(self, message: object, payload: Any | None = None) -> None:
+        """Initialize a Carrier API exception.
+
+        Args:
+            message: Human-readable error message or raw Carrier error payload.
+            payload: Optional structured error payload from Carrier.
+        """
+        super().__init__(message)
+        self.payload = payload
 
 
-class AuthError(GraphQLError):
+class AuthError(BaseError):
     """Raised when Carrier authentication fails or returns an unsuccessful result."""

--- a/src/carrier_api/errors.py
+++ b/src/carrier_api/errors.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from aiohttp import ClientError
+
 
 class CarrierApiError(Exception):
     """Base exception for Carrier API failures."""
@@ -21,12 +23,20 @@ class CarrierApiAuthError(CarrierApiError):
     """Raised when Carrier authentication fails or returns an unsuccessful result."""
 
 
+class CarrierApiConnectionError(CarrierApiError, ClientError):
+    """Raised when Carrier API communication fails before a valid API response."""
+
+
 class CarrierApiGraphqlError(CarrierApiError):
     """Raised when an authenticated Carrier GraphQL operation fails."""
 
 
-class CarrierApiTokenRefreshError(CarrierApiAuthError):
+class CarrierApiTokenRefreshError(CarrierApiConnectionError):
     """Raised when Carrier access token refresh fails."""
+
+
+class CarrierApiWebsocketError(CarrierApiConnectionError):
+    """Raised when Carrier realtime websocket communication fails."""
 
 
 # Deprecated compatibility aliases. These will be removed in a future release.

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -3,9 +3,9 @@
 from datetime import UTC, datetime, timedelta
 from typing import Any, Self, cast
 
-from aiohttp import ClientSession
+from aiohttp import ClientConnectionError, ClientError, ClientResponseError, ClientSession
 from gql import GraphQLRequest, gql
-from gql.transport.exceptions import TransportQueryError
+from gql.transport.exceptions import TransportQueryError, TransportServerError
 import pytest
 
 import carrier_api
@@ -254,15 +254,23 @@ def test_public_error_exports_use_carrier_api_prefix() -> None:
     """Expose Carrier-prefixed public API exception classes."""
     assert errors.CarrierApiError.__name__ == "CarrierApiError"
     assert errors.CarrierApiAuthError.__name__ == "CarrierApiAuthError"
+    assert errors.CarrierApiConnectionError.__name__ == "CarrierApiConnectionError"
     assert errors.CarrierApiGraphqlError.__name__ == "CarrierApiGraphqlError"
     assert errors.CarrierApiTokenRefreshError.__name__ == "CarrierApiTokenRefreshError"
+    assert errors.CarrierApiWebsocketError.__name__ == "CarrierApiWebsocketError"
     assert issubclass(errors.CarrierApiAuthError, errors.CarrierApiError)
+    assert issubclass(errors.CarrierApiConnectionError, errors.CarrierApiError)
+    assert issubclass(errors.CarrierApiConnectionError, ClientError)
     assert issubclass(errors.CarrierApiGraphqlError, errors.CarrierApiError)
-    assert issubclass(errors.CarrierApiTokenRefreshError, errors.CarrierApiError)
+    assert issubclass(errors.CarrierApiTokenRefreshError, errors.CarrierApiConnectionError)
+    assert not issubclass(errors.CarrierApiTokenRefreshError, errors.CarrierApiAuthError)
+    assert issubclass(errors.CarrierApiWebsocketError, errors.CarrierApiConnectionError)
     assert carrier_api.CarrierApiError is errors.CarrierApiError
     assert carrier_api.CarrierApiAuthError is errors.CarrierApiAuthError
+    assert carrier_api.CarrierApiConnectionError is errors.CarrierApiConnectionError
     assert carrier_api.CarrierApiGraphqlError is errors.CarrierApiGraphqlError
     assert carrier_api.CarrierApiTokenRefreshError is errors.CarrierApiTokenRefreshError
+    assert carrier_api.CarrierApiWebsocketError is errors.CarrierApiWebsocketError
 
 
 def test_graphql_error_tuple_catches_transport_query_errors() -> None:
@@ -346,6 +354,38 @@ async def test_refresh_auth_token_wraps_refresh_failures() -> None:
 
 
 @pytest.mark.asyncio
+async def test_refresh_auth_token_preserves_unauthorized_response_as_auth_error() -> None:
+    """Raise auth errors for unauthorized token refresh responses."""
+    refresh_error = ClientResponseError(
+        request_info=None,  # type: ignore[arg-type]
+        history=(),
+        status=401,
+        message="unauthorized",
+    )
+
+    class UnauthorizedResponse(FakeResponse):
+        """Response double that raises an unauthorized status."""
+
+        def raise_for_status(self) -> None:
+            """Raise the configured unauthorized response error."""
+            raise refresh_error
+
+    session = FakeSession()
+    session.response = UnauthorizedResponse({})
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", session),
+    )
+    connection.refresh_token = "old-refresh"
+
+    with pytest.raises(errors.CarrierApiAuthError) as error:
+        await connection.refresh_auth_token()
+
+    assert error.value.__cause__ is refresh_error
+
+
+@pytest.mark.asyncio
 async def test_check_auth_expiration_logs_in_then_refreshes_when_expired(
     connection: SpyConnection,
 ) -> None:
@@ -364,8 +404,8 @@ async def test_check_auth_expiration_logs_in_then_refreshes_when_expired(
 
 
 @pytest.mark.asyncio
-async def test_login_wraps_graphql_transport_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Raise Carrier auth errors instead of raw GraphQL transport exceptions.
+async def test_login_wraps_graphql_query_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Raise Carrier GraphQL errors instead of raw GraphQL query exceptions.
 
     Args:
         monkeypatch: Pytest helper for replacing the GraphQL client.
@@ -400,7 +440,7 @@ async def test_login_wraps_graphql_transport_errors(monkeypatch: pytest.MonkeyPa
         client_session=cast("ClientSession", FakeSession()),
     )
 
-    with pytest.raises(errors.CarrierApiAuthError) as error:
+    with pytest.raises(errors.CarrierApiGraphqlError) as error:
         await connection.login()
 
     assert error.value.__cause__ is transport_error
@@ -408,7 +448,7 @@ async def test_login_wraps_graphql_transport_errors(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
-async def test_authed_query_wraps_graphql_transport_errors(
+async def test_authed_query_wraps_graphql_query_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Raise Carrier API errors instead of raw GraphQL transport exceptions.
@@ -451,6 +491,67 @@ async def test_authed_query_wraps_graphql_transport_errors(
     connection.expires_at = datetime.now(UTC) + timedelta(hours=1)
 
     with pytest.raises(errors.CarrierApiGraphqlError) as error:
+        await connection.authed_query(
+            operation_name="getUser",
+            query=cast("GraphQLRequest", object()),
+            variable_values={},
+        )
+
+    assert error.value.__cause__ is transport_error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "transport_error",
+    [
+        TransportServerError("server unavailable", code=503),
+        ClientConnectionError("connection failed"),
+    ],
+)
+async def test_authed_query_wraps_connection_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    transport_error: Exception,
+) -> None:
+    """Raise Carrier connection errors instead of raw network exceptions.
+
+    Args:
+        monkeypatch: Pytest helper for replacing the GraphQL client.
+        transport_error: Network or transport exception raised by the fake client.
+    """
+
+    class FailingClient:
+        """GraphQL client double that raises during authenticated execution."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            """Accept GraphQL client construction arguments."""
+
+        async def __aenter__(self) -> Self:
+            """Return the fake session.
+
+            Returns:
+                The fake GraphQL session.
+            """
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            """Exit the fake session context."""
+
+        async def execute(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            """Raise the configured connection error."""
+            raise transport_error
+
+    monkeypatch.setattr("carrier_api.api_connection_graphql.Client", FailingClient)
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", FakeSession()),
+    )
+    connection.refresh_token = "refresh"
+    connection.token_type = "Bearer"
+    connection.access_token = "access"
+    connection.expires_at = datetime.now(UTC) + timedelta(hours=1)
+
+    with pytest.raises(errors.CarrierApiConnectionError) as error:
         await connection.authed_query(
             operation_name="getUser",
             query=cast("GraphQLRequest", object()),

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -474,6 +474,93 @@ async def test_refresh_auth_token_treats_invalid_grant_as_auth_error() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [None, ["invalid_grant"], "invalid_grant"])
+async def test_refresh_auth_token_ignores_non_object_error_payloads(
+    payload: object,
+) -> None:
+    """Keep non-object refresh error payloads in the refresh-failure bucket.
+
+    Args:
+        payload: Non-object JSON payload returned by the fake response.
+    """
+    refresh_error = ClientResponseError(
+        request_info=None,  # type: ignore[arg-type]
+        history=(),
+        status=400,
+        message="bad request",
+    )
+
+    class NonObjectErrorResponse(FakeResponse):
+        """Response double that returns a non-object OAuth error payload."""
+
+        def raise_for_status(self) -> None:
+            """Raise the configured bad request response error."""
+            raise refresh_error
+
+        async def json(self) -> Any:
+            """Return the configured non-object JSON payload.
+
+            Returns:
+                The configured non-object payload.
+            """
+            return payload
+
+    session = FakeSession()
+    session.response = NonObjectErrorResponse({})
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", session),
+    )
+    connection.refresh_token = "old-refresh"
+
+    with pytest.raises(errors.CarrierApiTokenRefreshError) as error:
+        await connection.refresh_auth_token()
+
+    assert error.value.__cause__ is refresh_error
+
+
+@pytest.mark.asyncio
+async def test_refresh_auth_token_normalizes_malformed_error_payload() -> None:
+    """Keep malformed refresh error payloads normalized as Carrier errors."""
+    refresh_error = ClientResponseError(
+        request_info=None,  # type: ignore[arg-type]
+        history=(),
+        status=400,
+        message="bad request",
+    )
+
+    class MalformedErrorResponse(FakeResponse):
+        """Response double that raises while decoding the OAuth error payload."""
+
+        def raise_for_status(self) -> None:
+            """Raise the configured bad request response error."""
+            raise refresh_error
+
+        async def json(self) -> dict[str, Any]:
+            """Raise a JSON decode-style failure.
+
+            Raises:
+                ValueError: Always raised for this malformed response.
+            """
+            raise ValueError("invalid json")
+
+    session = FakeSession()
+    session.response = MalformedErrorResponse({})
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", session),
+    )
+    connection.refresh_token = "old-refresh"
+
+    with pytest.raises(errors.CarrierApiTokenRefreshError) as error:
+        await connection.refresh_auth_token()
+
+    assert error.value.__cause__ is refresh_error
+
+
+@pytest.mark.asyncio
 async def test_check_auth_expiration_logs_in_then_refreshes_when_expired(
     connection: SpyConnection,
 ) -> None:

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -561,6 +561,46 @@ async def test_refresh_auth_token_normalizes_malformed_error_payload() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "cause_type"),
+    [
+        (
+            {
+                "expires_in": 3600,
+                "token_type": "Bearer",
+                "access_token": "new-access",
+            },
+            KeyError,
+        ),
+        (None, TypeError),
+    ],
+)
+async def test_refresh_auth_token_normalizes_malformed_success_payloads(
+    payload: object,
+    cause_type: type[BaseException],
+) -> None:
+    """Raise token refresh errors for malformed successful OAuth responses.
+
+    Args:
+        payload: Malformed successful OAuth payload returned by the fake response.
+        cause_type: Expected original exception type preserved as the cause.
+    """
+    session = FakeSession()
+    session.response = FakeResponse(cast("dict[str, Any]", payload))
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", session),
+    )
+    connection.refresh_token = "old-refresh"
+
+    with pytest.raises(errors.CarrierApiTokenRefreshError) as error:
+        await connection.refresh_auth_token()
+
+    assert isinstance(error.value.__cause__, cause_type)
+
+
+@pytest.mark.asyncio
 async def test_check_auth_expiration_logs_in_then_refreshes_when_expired(
     connection: SpyConnection,
 ) -> None:

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -271,11 +271,67 @@ def test_public_error_exports_use_carrier_api_prefix() -> None:
     assert carrier_api.CarrierApiGraphqlError is errors.CarrierApiGraphqlError
     assert carrier_api.CarrierApiTokenRefreshError is errors.CarrierApiTokenRefreshError
     assert carrier_api.CarrierApiWebsocketError is errors.CarrierApiWebsocketError
+    assert errors.AuthError is errors.CarrierApiAuthError
+    assert errors.BaseError is errors.CarrierApiError
+    assert carrier_api.AuthError is errors.CarrierApiAuthError
+    assert carrier_api.BaseError is errors.CarrierApiError
 
 
 def test_graphql_error_tuple_catches_transport_query_errors() -> None:
     """Include query errors explicitly in the wrapped GraphQL error set."""
     assert TransportQueryError in _GRAPHQL_ERRORS
+
+
+@pytest.mark.asyncio
+async def test_login_failure_preserves_auth_payload_in_exception_args(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep legacy auth failure payload access while exposing ``payload``.
+
+    Args:
+        monkeypatch: Pytest helper for replacing the GraphQL client.
+    """
+    payload = {
+        "assistedLogin": {
+            "success": False,
+            "status": "FAILED",
+            "errorMessage": "invalid credentials",
+        }
+    }
+
+    class FailedLoginClient:
+        """GraphQL client double that returns a failed assisted login."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            """Accept GraphQL client construction arguments."""
+
+        async def __aenter__(self) -> Self:
+            """Return the fake session.
+
+            Returns:
+                The fake GraphQL session.
+            """
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            """Exit the fake session context."""
+
+        async def execute(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            """Return the configured failed login payload."""
+            return payload
+
+    monkeypatch.setattr("carrier_api.api_connection_graphql.Client", FailedLoginClient)
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", FakeSession()),
+    )
+
+    with pytest.raises(errors.CarrierApiAuthError) as error:
+        await connection.login()
+
+    assert error.value.args[0] == payload
+    assert error.value.payload == payload
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -5,8 +5,10 @@ from typing import Any, Self, cast
 
 from aiohttp import ClientSession
 from gql import GraphQLRequest, gql
+from gql.transport.exceptions import TransportQueryError
 import pytest
 
+from carrier_api import errors
 from carrier_api.api_connection_graphql import ApiConnectionGraphql
 from carrier_api.const import ActivityTypes, FanModes, HeatSourceTypes, SystemModes
 from carrier_api.system import System
@@ -305,6 +307,103 @@ async def test_check_auth_expiration_logs_in_then_refreshes_when_expired(
 
     assert connection.login_count == 1
     assert connection.refresh_count == 1
+
+
+@pytest.mark.asyncio
+async def test_login_wraps_graphql_transport_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Raise Carrier auth errors instead of raw GraphQL transport exceptions.
+
+    Args:
+        monkeypatch: Pytest helper for replacing the GraphQL client.
+    """
+    transport_error = TransportQueryError("invalid credentials")
+
+    class FailingClient:
+        """GraphQL client double that raises during login execution."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            """Accept GraphQL client construction arguments."""
+
+        async def __aenter__(self) -> Self:
+            """Return the fake session.
+
+            Returns:
+                The fake GraphQL session.
+            """
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            """Exit the fake session context."""
+
+        async def execute(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            """Raise the configured transport error."""
+            raise transport_error
+
+    monkeypatch.setattr("carrier_api.api_connection_graphql.Client", FailingClient)
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", FakeSession()),
+    )
+
+    with pytest.raises(errors.AuthError) as error:
+        await connection.login()
+
+    assert error.value.__cause__ is transport_error
+    assert isinstance(error.value, errors.BaseError)
+
+
+@pytest.mark.asyncio
+async def test_authed_query_wraps_graphql_transport_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Raise Carrier API errors instead of raw GraphQL transport exceptions.
+
+    Args:
+        monkeypatch: Pytest helper for replacing the GraphQL client.
+    """
+    transport_error = TransportQueryError("query failed")
+
+    class FailingClient:
+        """GraphQL client double that raises during authenticated execution."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            """Accept GraphQL client construction arguments."""
+
+        async def __aenter__(self) -> Self:
+            """Return the fake session.
+
+            Returns:
+                The fake GraphQL session.
+            """
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            """Exit the fake session context."""
+
+        async def execute(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            """Raise the configured transport error."""
+            raise transport_error
+
+    monkeypatch.setattr("carrier_api.api_connection_graphql.Client", FailingClient)
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", FakeSession()),
+    )
+    connection.refresh_token = "refresh"
+    connection.token_type = "Bearer"
+    connection.access_token = "access"
+    connection.expires_at = datetime.now(UTC) + timedelta(hours=1)
+
+    with pytest.raises(errors.BaseError) as error:
+        await connection.authed_query(
+            operation_name="getUser",
+            query=cast("GraphQLRequest", object()),
+            variable_values={},
+        )
+
+    assert error.value.__cause__ is transport_error
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -18,7 +18,7 @@ from carrier_api.system import System
 class FakeResponse:
     """Minimal aiohttp response double for token refresh tests."""
 
-    def __init__(self, payload: dict[str, Any]) -> None:
+    def __init__(self, payload: object) -> None:
         """Initialize the fake response with JSON payload data.
 
         Args:
@@ -31,7 +31,7 @@ class FakeResponse:
         """Record that response status validation was requested."""
         self.raise_for_status_called = True
 
-    async def json(self) -> dict[str, Any]:
+    async def json(self) -> object:
         """Return the configured JSON payload.
 
         Returns:
@@ -586,7 +586,7 @@ async def test_refresh_auth_token_normalizes_malformed_success_payloads(
         cause_type: Expected original exception type preserved as the cause.
     """
     session = FakeSession()
-    session.response = FakeResponse(cast("dict[str, Any]", payload))
+    session.response = FakeResponse(payload)
     connection = ApiConnectionGraphql(
         username="user@example.com",
         password="password",

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -8,8 +8,9 @@ from gql import GraphQLRequest, gql
 from gql.transport.exceptions import TransportQueryError
 import pytest
 
+import carrier_api
 from carrier_api import errors
-from carrier_api.api_connection_graphql import ApiConnectionGraphql
+from carrier_api.api_connection_graphql import _GRAPHQL_ERRORS, ApiConnectionGraphql
 from carrier_api.const import ActivityTypes, FanModes, HeatSourceTypes, SystemModes
 from carrier_api.system import System
 
@@ -258,6 +259,15 @@ def test_public_error_exports_use_carrier_api_prefix() -> None:
     assert issubclass(errors.CarrierApiAuthError, errors.CarrierApiError)
     assert issubclass(errors.CarrierApiGraphqlError, errors.CarrierApiError)
     assert issubclass(errors.CarrierApiTokenRefreshError, errors.CarrierApiError)
+    assert carrier_api.CarrierApiError is errors.CarrierApiError
+    assert carrier_api.CarrierApiAuthError is errors.CarrierApiAuthError
+    assert carrier_api.CarrierApiGraphqlError is errors.CarrierApiGraphqlError
+    assert carrier_api.CarrierApiTokenRefreshError is errors.CarrierApiTokenRefreshError
+
+
+def test_graphql_error_tuple_catches_transport_query_errors() -> None:
+    """Include query errors explicitly in the wrapped GraphQL error set."""
+    assert TransportQueryError in _GRAPHQL_ERRORS
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -400,6 +400,48 @@ async def test_cleanup_closes_provided_session() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cleanup_error",
+    [
+        ClientConnectionError("cleanup connection failed"),
+        TimeoutError("cleanup timed out"),
+        OSError("cleanup socket failed"),
+    ],
+)
+async def test_cleanup_wraps_session_close_errors(
+    cleanup_error: ClientError | TimeoutError | OSError,
+) -> None:
+    """Raise Carrier connection errors instead of raw session cleanup errors.
+
+    Args:
+        cleanup_error: Error raised by the fake session close.
+    """
+
+    class FailingCloseSession(FakeSession):
+        """Session double that fails during cleanup."""
+
+        async def close(self) -> None:
+            """Raise the configured cleanup error.
+
+            Raises:
+                ClientError | TimeoutError | OSError: Always raised for this
+                    failing session.
+            """
+            raise cleanup_error
+
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", FailingCloseSession()),
+    )
+
+    with pytest.raises(errors.CarrierApiConnectionError) as error:
+        await connection.cleanup()
+
+    assert error.value.__cause__ is cleanup_error
+
+
+@pytest.mark.asyncio
 async def test_refresh_auth_token_updates_token_state() -> None:
     """Refresh auth tokens from the OAuth response payload."""
     session = FakeSession()
@@ -427,9 +469,18 @@ async def test_refresh_auth_token_updates_token_state() -> None:
 
 
 @pytest.mark.asyncio
-async def test_refresh_auth_token_wraps_refresh_failures() -> None:
+@pytest.mark.parametrize(
+    "refresh_error",
+    [
+        ClientConnectionError("token refresh connection failed"),
+        TimeoutError("token refresh timed out"),
+        OSError("token refresh socket failed"),
+    ],
+)
+async def test_refresh_auth_token_wraps_refresh_failures(
+    refresh_error: ClientError | TimeoutError | OSError,
+) -> None:
     """Raise Carrier token refresh errors instead of raw HTTP exceptions."""
-    refresh_error = TimeoutError("token refresh timed out")
 
     class FailingSession(FakeSession):
         """Session double that fails token refresh requests."""
@@ -442,7 +493,8 @@ async def test_refresh_auth_token_wraps_refresh_failures() -> None:
                 data: Submitted form data.
 
             Raises:
-                TimeoutError: Always raised for this failing session.
+                ClientError | TimeoutError | OSError: Always raised for this
+                    failing session.
             """
             raise refresh_error
 
@@ -483,6 +535,48 @@ async def test_refresh_auth_token_treats_auth_rejections_as_auth_error(
 
     session = FakeSession()
     session.response = FakeResponse(payload, status_error=refresh_error)
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", session),
+    )
+    connection.refresh_token = "old-refresh"
+
+    with pytest.raises(errors.CarrierApiAuthError) as error:
+        await connection.refresh_auth_token()
+
+    assert error.value.__cause__ is refresh_error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "json_error",
+    [
+        TimeoutError("refresh error body timed out"),
+        OSError("refresh error body socket failed"),
+    ],
+)
+async def test_refresh_auth_token_normalizes_unreadable_error_payloads(
+    json_error: TimeoutError | OSError,
+) -> None:
+    """Raise Carrier errors when refresh error payload reads fail.
+
+    Args:
+        json_error: Error raised while reading the refresh error response body.
+    """
+    refresh_error = ClientResponseError(
+        request_info=None,  # type: ignore[arg-type]
+        history=(),
+        status=401,
+        message="unauthorized",
+    )
+
+    session = FakeSession()
+    session.response = FakeResponse(
+        {},
+        status_error=refresh_error,
+        json_error=json_error,
+    )
     connection = ApiConnectionGraphql(
         username="user@example.com",
         password="password",
@@ -641,6 +735,40 @@ async def test_login_wraps_graphql_query_errors(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "transport_error",
+    [
+        ClientConnectionError("connection failed"),
+        TimeoutError("connection timed out"),
+        OSError("socket failed"),
+    ],
+)
+async def test_login_wraps_connection_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    transport_error: ClientError | TimeoutError | OSError,
+) -> None:
+    """Raise Carrier connection errors instead of raw login transport exceptions.
+
+    Args:
+        monkeypatch: Pytest helper for replacing the GraphQL client.
+        transport_error: Network or transport exception raised by the fake client.
+    """
+    monkeypatch.setattr(
+        "carrier_api.api_connection_graphql.Client", graphql_client_double(error=transport_error)
+    )
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", FakeSession()),
+    )
+
+    with pytest.raises(errors.CarrierApiConnectionError) as error:
+        await connection.login()
+
+    assert error.value.__cause__ is transport_error
+
+
+@pytest.mark.asyncio
 async def test_authed_query_wraps_graphql_query_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -680,11 +808,13 @@ async def test_authed_query_wraps_graphql_query_errors(
     [
         TransportServerError("server unavailable", code=503),
         ClientConnectionError("connection failed"),
+        TimeoutError("connection timed out"),
+        OSError("socket failed"),
     ],
 )
 async def test_authed_query_wraps_connection_errors(
     monkeypatch: pytest.MonkeyPatch,
-    transport_error: Exception,
+    transport_error: Exception | TimeoutError | OSError,
 ) -> None:
     """Raise Carrier connection errors instead of raw network exceptions.
 
@@ -779,6 +909,47 @@ async def test_query_helpers_send_expected_operation_and_variables(
         ("getInfinitySystems", {"userName": "user@example.com"}),
         ("getInfinityEnergy", {"serial": "SERIAL"}),
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "transport_error"),
+    [
+        ("get_user_info", TimeoutError("get user timed out")),
+        ("get_user_info", OSError("get user socket failed")),
+        ("load_data", TimeoutError("load data timed out")),
+        ("load_data", OSError("load data socket failed")),
+    ],
+)
+async def test_public_query_helpers_preserve_connection_error_normalization(
+    monkeypatch: pytest.MonkeyPatch,
+    method_name: str,
+    transport_error: TimeoutError | OSError,
+) -> None:
+    """Keep public query helpers from leaking raw network exceptions.
+
+    Args:
+        monkeypatch: Pytest helper for replacing the GraphQL client.
+        method_name: Public helper method called by API consumers.
+        transport_error: Network exception raised by the fake client.
+    """
+    monkeypatch.setattr(
+        "carrier_api.api_connection_graphql.Client", graphql_client_double(error=transport_error)
+    )
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", FakeSession()),
+    )
+    connection.refresh_token = "refresh"
+    connection.token_type = "Bearer"
+    connection.access_token = "access"
+    connection.expires_at = datetime.now(UTC) + timedelta(hours=1)
+
+    with pytest.raises(errors.CarrierApiConnectionError) as error:
+        await getattr(connection, method_name)()
+
+    assert error.value.__cause__ is transport_error
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -442,6 +442,38 @@ async def test_refresh_auth_token_preserves_unauthorized_response_as_auth_error(
 
 
 @pytest.mark.asyncio
+async def test_refresh_auth_token_treats_invalid_grant_as_auth_error() -> None:
+    """Raise auth errors for OAuth invalid_grant token refresh responses."""
+    refresh_error = ClientResponseError(
+        request_info=None,  # type: ignore[arg-type]
+        history=(),
+        status=400,
+        message="bad request",
+    )
+
+    class InvalidGrantResponse(FakeResponse):
+        """Response double that raises an invalid_grant OAuth error."""
+
+        def raise_for_status(self) -> None:
+            """Raise the configured invalid_grant response error."""
+            raise refresh_error
+
+    session = FakeSession()
+    session.response = InvalidGrantResponse({"error": "invalid_grant"})
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", session),
+    )
+    connection.refresh_token = "old-refresh"
+
+    with pytest.raises(errors.CarrierApiAuthError) as error:
+        await connection.refresh_auth_token()
+
+    assert error.value.__cause__ is refresh_error
+
+
+@pytest.mark.asyncio
 async def test_check_auth_expiration_logs_in_then_refreshes_when_expired(
     connection: SpyConnection,
 ) -> None:

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -249,6 +249,17 @@ def connection() -> SpyConnection:
     return SpyConnection()
 
 
+def test_public_error_exports_use_carrier_api_prefix() -> None:
+    """Expose Carrier-prefixed public API exception classes."""
+    assert errors.CarrierApiError.__name__ == "CarrierApiError"
+    assert errors.CarrierApiAuthError.__name__ == "CarrierApiAuthError"
+    assert errors.CarrierApiGraphqlError.__name__ == "CarrierApiGraphqlError"
+    assert errors.CarrierApiTokenRefreshError.__name__ == "CarrierApiTokenRefreshError"
+    assert issubclass(errors.CarrierApiAuthError, errors.CarrierApiError)
+    assert issubclass(errors.CarrierApiGraphqlError, errors.CarrierApiError)
+    assert issubclass(errors.CarrierApiTokenRefreshError, errors.CarrierApiError)
+
+
 @pytest.mark.asyncio
 async def test_cleanup_closes_provided_session() -> None:
     """Close the underlying HTTP session."""
@@ -289,6 +300,39 @@ async def test_refresh_auth_token_updates_token_state() -> None:
     assert connection.access_token == "new-access"
     assert connection.refresh_token == "new-refresh"
     assert connection.expires_at > datetime.now(UTC)
+
+
+@pytest.mark.asyncio
+async def test_refresh_auth_token_wraps_refresh_failures() -> None:
+    """Raise Carrier token refresh errors instead of raw HTTP exceptions."""
+    refresh_error = TimeoutError("token refresh timed out")
+
+    class FailingSession(FakeSession):
+        """Session double that fails token refresh requests."""
+
+        async def post(self, url: str, data: dict[str, Any]) -> FakeResponse:
+            """Raise the configured refresh error.
+
+            Args:
+                url: Requested URL.
+                data: Submitted form data.
+
+            Raises:
+                TimeoutError: Always raised for this failing session.
+            """
+            raise refresh_error
+
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", FailingSession()),
+    )
+    connection.refresh_token = "old-refresh"
+
+    with pytest.raises(errors.CarrierApiTokenRefreshError) as error:
+        await connection.refresh_auth_token()
+
+    assert error.value.__cause__ is refresh_error
 
 
 @pytest.mark.asyncio
@@ -346,11 +390,11 @@ async def test_login_wraps_graphql_transport_errors(monkeypatch: pytest.MonkeyPa
         client_session=cast("ClientSession", FakeSession()),
     )
 
-    with pytest.raises(errors.AuthError) as error:
+    with pytest.raises(errors.CarrierApiAuthError) as error:
         await connection.login()
 
     assert error.value.__cause__ is transport_error
-    assert isinstance(error.value, errors.BaseError)
+    assert isinstance(error.value, errors.CarrierApiError)
 
 
 @pytest.mark.asyncio
@@ -396,7 +440,7 @@ async def test_authed_query_wraps_graphql_transport_errors(
     connection.access_token = "access"
     connection.expires_at = datetime.now(UTC) + timedelta(hours=1)
 
-    with pytest.raises(errors.BaseError) as error:
+    with pytest.raises(errors.CarrierApiGraphqlError) as error:
         await connection.authed_query(
             operation_name="getUser",
             query=cast("GraphQLRequest", object()),

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -352,10 +352,10 @@ def test_graphql_error_tuple_catches_transport_query_errors() -> None:
 
 
 @pytest.mark.asyncio
-async def test_login_failure_preserves_auth_payload_in_exception_args(
+async def test_login_failure_uses_readable_message_and_preserves_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Keep legacy auth failure payload access while exposing ``payload``.
+    """Expose a readable auth failure message while preserving payload access.
 
     Args:
         monkeypatch: Pytest helper for replacing the GraphQL client.
@@ -380,7 +380,7 @@ async def test_login_failure_preserves_auth_payload_in_exception_args(
     with pytest.raises(errors.CarrierApiAuthError) as error:
         await connection.login()
 
-    assert error.value.args[0] == payload
+    assert error.value.args[0] == "Carrier assistedLogin failed: invalid credentials"
     assert error.value.payload == payload
 
 

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -650,6 +650,62 @@ async def test_authed_query_wraps_connection_errors(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("status", [401, 403])
+async def test_authed_query_maps_auth_transport_errors_to_auth_error(
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+) -> None:
+    """Raise auth errors when GraphQL transport reports auth HTTP statuses.
+
+    Args:
+        monkeypatch: Pytest helper for replacing the GraphQL client.
+        status: HTTP status raised by the fake GraphQL transport.
+    """
+    transport_error = TransportServerError("unauthorized", code=status)
+
+    class FailingClient:
+        """GraphQL client double that raises during authenticated execution."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            """Accept GraphQL client construction arguments."""
+
+        async def __aenter__(self) -> Self:
+            """Return the fake session.
+
+            Returns:
+                The fake GraphQL session.
+            """
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            """Exit the fake session context."""
+
+        async def execute(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            """Raise the configured auth transport error."""
+            raise transport_error
+
+    monkeypatch.setattr("carrier_api.api_connection_graphql.Client", FailingClient)
+    connection = ApiConnectionGraphql(
+        username="user@example.com",
+        password="password",
+        client_session=cast("ClientSession", FakeSession()),
+    )
+    connection.refresh_token = "refresh"
+    connection.token_type = "Bearer"
+    connection.access_token = "access"
+    connection.expires_at = datetime.now(UTC) + timedelta(hours=1)
+
+    with pytest.raises(errors.CarrierApiAuthError) as error:
+        await connection.authed_query(
+            operation_name="getUser",
+            query=cast("GraphQLRequest", object()),
+            variable_values={},
+        )
+
+    assert error.value.__cause__ is transport_error
+
+
+@pytest.mark.asyncio
 async def test_query_helpers_send_expected_operation_and_variables(
     connection: SpyConnection,
 ) -> None:

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -18,25 +18,45 @@ from carrier_api.system import System
 class FakeResponse:
     """Minimal aiohttp response double for token refresh tests."""
 
-    def __init__(self, payload: object) -> None:
+    def __init__(
+        self,
+        payload: object,
+        status_error: ClientResponseError | None = None,
+        json_error: BaseException | None = None,
+    ) -> None:
         """Initialize the fake response with JSON payload data.
 
         Args:
             payload: Data returned from ``json``.
+            status_error: Optional error raised by ``raise_for_status``.
+            json_error: Optional error raised by ``json``.
         """
         self.payload = payload
+        self.status_error = status_error
+        self.json_error = json_error
         self.raise_for_status_called = False
 
     def raise_for_status(self) -> None:
-        """Record that response status validation was requested."""
+        """Record status validation and raise the configured status error.
+
+        Raises:
+            ClientResponseError: When ``status_error`` is configured.
+        """
         self.raise_for_status_called = True
+        if self.status_error is not None:
+            raise self.status_error
 
     async def json(self) -> object:
         """Return the configured JSON payload.
 
         Returns:
             The fake response payload.
+
+        Raises:
+            BaseException: When ``json_error`` is configured.
         """
+        if self.json_error is not None:
+            raise self.json_error
         return self.payload
 
 
@@ -127,6 +147,55 @@ class FakeGraphQLClient:
             "variables": variable_values,
             "operation_name": operation_name,
         }
+
+
+def graphql_client_double(
+    *,
+    result: dict[str, Any] | None = None,
+    error: BaseException | None = None,
+) -> type[object]:
+    """Create a GraphQL client double that returns or raises during execute.
+
+    Args:
+        result: Optional GraphQL result returned by ``execute``.
+        error: Optional error raised by ``execute``.
+
+    Returns:
+        A GraphQL client double class suitable for monkeypatching ``Client``.
+    """
+
+    class ConfiguredGraphQLClient:
+        """GraphQL client double with configured execute behavior."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            """Accept GraphQL client construction arguments."""
+
+        async def __aenter__(self) -> Self:
+            """Return the fake session.
+
+            Returns:
+                The fake GraphQL session.
+            """
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            """Exit the fake session context."""
+
+        async def execute(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            """Return or raise the configured GraphQL result.
+
+            Returns:
+                The configured GraphQL result.
+
+            Raises:
+                BaseException: When ``error`` is configured.
+            """
+            if error is not None:
+                raise error
+            assert result is not None
+            return result
+
+    return ConfiguredGraphQLClient
 
 
 class SpyConnection(ApiConnectionGraphql):
@@ -299,28 +368,9 @@ async def test_login_failure_preserves_auth_payload_in_exception_args(
         }
     }
 
-    class FailedLoginClient:
-        """GraphQL client double that returns a failed assisted login."""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            """Accept GraphQL client construction arguments."""
-
-        async def __aenter__(self) -> Self:
-            """Return the fake session.
-
-            Returns:
-                The fake GraphQL session.
-            """
-            return self
-
-        async def __aexit__(self, *args: object) -> None:
-            """Exit the fake session context."""
-
-        async def execute(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-            """Return the configured failed login payload."""
-            return payload
-
-    monkeypatch.setattr("carrier_api.api_connection_graphql.Client", FailedLoginClient)
+    monkeypatch.setattr(
+        "carrier_api.api_connection_graphql.Client", graphql_client_double(result=payload)
+    )
     connection = ApiConnectionGraphql(
         username="user@example.com",
         password="password",
@@ -410,56 +460,29 @@ async def test_refresh_auth_token_wraps_refresh_failures() -> None:
 
 
 @pytest.mark.asyncio
-async def test_refresh_auth_token_preserves_unauthorized_response_as_auth_error() -> None:
-    """Raise auth errors for unauthorized token refresh responses."""
+@pytest.mark.parametrize(
+    ("status", "payload"),
+    [(401, {}), (400, {"error": "invalid_grant"})],
+)
+async def test_refresh_auth_token_treats_auth_rejections_as_auth_error(
+    status: int,
+    payload: object,
+) -> None:
+    """Raise auth errors for rejected token refresh responses.
+
+    Args:
+        status: HTTP status returned by the fake token endpoint.
+        payload: JSON payload returned by the fake token endpoint.
+    """
     refresh_error = ClientResponseError(
         request_info=None,  # type: ignore[arg-type]
         history=(),
-        status=401,
-        message="unauthorized",
+        status=status,
+        message="token rejected",
     )
-
-    class UnauthorizedResponse(FakeResponse):
-        """Response double that raises an unauthorized status."""
-
-        def raise_for_status(self) -> None:
-            """Raise the configured unauthorized response error."""
-            raise refresh_error
 
     session = FakeSession()
-    session.response = UnauthorizedResponse({})
-    connection = ApiConnectionGraphql(
-        username="user@example.com",
-        password="password",
-        client_session=cast("ClientSession", session),
-    )
-    connection.refresh_token = "old-refresh"
-
-    with pytest.raises(errors.CarrierApiAuthError) as error:
-        await connection.refresh_auth_token()
-
-    assert error.value.__cause__ is refresh_error
-
-
-@pytest.mark.asyncio
-async def test_refresh_auth_token_treats_invalid_grant_as_auth_error() -> None:
-    """Raise auth errors for OAuth invalid_grant token refresh responses."""
-    refresh_error = ClientResponseError(
-        request_info=None,  # type: ignore[arg-type]
-        history=(),
-        status=400,
-        message="bad request",
-    )
-
-    class InvalidGrantResponse(FakeResponse):
-        """Response double that raises an invalid_grant OAuth error."""
-
-        def raise_for_status(self) -> None:
-            """Raise the configured invalid_grant response error."""
-            raise refresh_error
-
-    session = FakeSession()
-    session.response = InvalidGrantResponse({"error": "invalid_grant"})
+    session.response = FakeResponse(payload, status_error=refresh_error)
     connection = ApiConnectionGraphql(
         username="user@example.com",
         password="password",
@@ -490,23 +513,8 @@ async def test_refresh_auth_token_ignores_non_object_error_payloads(
         message="bad request",
     )
 
-    class NonObjectErrorResponse(FakeResponse):
-        """Response double that returns a non-object OAuth error payload."""
-
-        def raise_for_status(self) -> None:
-            """Raise the configured bad request response error."""
-            raise refresh_error
-
-        async def json(self) -> Any:
-            """Return the configured non-object JSON payload.
-
-            Returns:
-                The configured non-object payload.
-            """
-            return payload
-
     session = FakeSession()
-    session.response = NonObjectErrorResponse({})
+    session.response = FakeResponse(payload, status_error=refresh_error)
     connection = ApiConnectionGraphql(
         username="user@example.com",
         password="password",
@@ -530,23 +538,12 @@ async def test_refresh_auth_token_normalizes_malformed_error_payload() -> None:
         message="bad request",
     )
 
-    class MalformedErrorResponse(FakeResponse):
-        """Response double that raises while decoding the OAuth error payload."""
-
-        def raise_for_status(self) -> None:
-            """Raise the configured bad request response error."""
-            raise refresh_error
-
-        async def json(self) -> dict[str, Any]:
-            """Raise a JSON decode-style failure.
-
-            Raises:
-                ValueError: Always raised for this malformed response.
-            """
-            raise ValueError("invalid json")
-
     session = FakeSession()
-    session.response = MalformedErrorResponse({})
+    session.response = FakeResponse(
+        {},
+        status_error=refresh_error,
+        json_error=ValueError("invalid json"),
+    )
     connection = ApiConnectionGraphql(
         username="user@example.com",
         password="password",
@@ -627,28 +624,9 @@ async def test_login_wraps_graphql_query_errors(monkeypatch: pytest.MonkeyPatch)
     """
     transport_error = TransportQueryError("invalid credentials")
 
-    class FailingClient:
-        """GraphQL client double that raises during login execution."""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            """Accept GraphQL client construction arguments."""
-
-        async def __aenter__(self) -> Self:
-            """Return the fake session.
-
-            Returns:
-                The fake GraphQL session.
-            """
-            return self
-
-        async def __aexit__(self, *args: object) -> None:
-            """Exit the fake session context."""
-
-        async def execute(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-            """Raise the configured transport error."""
-            raise transport_error
-
-    monkeypatch.setattr("carrier_api.api_connection_graphql.Client", FailingClient)
+    monkeypatch.setattr(
+        "carrier_api.api_connection_graphql.Client", graphql_client_double(error=transport_error)
+    )
     connection = ApiConnectionGraphql(
         username="user@example.com",
         password="password",
@@ -673,28 +651,9 @@ async def test_authed_query_wraps_graphql_query_errors(
     """
     transport_error = TransportQueryError("query failed")
 
-    class FailingClient:
-        """GraphQL client double that raises during authenticated execution."""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            """Accept GraphQL client construction arguments."""
-
-        async def __aenter__(self) -> Self:
-            """Return the fake session.
-
-            Returns:
-                The fake GraphQL session.
-            """
-            return self
-
-        async def __aexit__(self, *args: object) -> None:
-            """Exit the fake session context."""
-
-        async def execute(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-            """Raise the configured transport error."""
-            raise transport_error
-
-    monkeypatch.setattr("carrier_api.api_connection_graphql.Client", FailingClient)
+    monkeypatch.setattr(
+        "carrier_api.api_connection_graphql.Client", graphql_client_double(error=transport_error)
+    )
     connection = ApiConnectionGraphql(
         username="user@example.com",
         password="password",
@@ -733,29 +692,9 @@ async def test_authed_query_wraps_connection_errors(
         monkeypatch: Pytest helper for replacing the GraphQL client.
         transport_error: Network or transport exception raised by the fake client.
     """
-
-    class FailingClient:
-        """GraphQL client double that raises during authenticated execution."""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            """Accept GraphQL client construction arguments."""
-
-        async def __aenter__(self) -> Self:
-            """Return the fake session.
-
-            Returns:
-                The fake GraphQL session.
-            """
-            return self
-
-        async def __aexit__(self, *args: object) -> None:
-            """Exit the fake session context."""
-
-        async def execute(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-            """Raise the configured connection error."""
-            raise transport_error
-
-    monkeypatch.setattr("carrier_api.api_connection_graphql.Client", FailingClient)
+    monkeypatch.setattr(
+        "carrier_api.api_connection_graphql.Client", graphql_client_double(error=transport_error)
+    )
     connection = ApiConnectionGraphql(
         username="user@example.com",
         password="password",
@@ -790,28 +729,9 @@ async def test_authed_query_maps_auth_transport_errors_to_auth_error(
     """
     transport_error = TransportServerError("unauthorized", code=status)
 
-    class FailingClient:
-        """GraphQL client double that raises during authenticated execution."""
-
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            """Accept GraphQL client construction arguments."""
-
-        async def __aenter__(self) -> Self:
-            """Return the fake session.
-
-            Returns:
-                The fake GraphQL session.
-            """
-            return self
-
-        async def __aexit__(self, *args: object) -> None:
-            """Exit the fake session context."""
-
-        async def execute(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-            """Raise the configured auth transport error."""
-            raise transport_error
-
-    monkeypatch.setattr("carrier_api.api_connection_graphql.Client", FailingClient)
+    monkeypatch.setattr(
+        "carrier_api.api_connection_graphql.Client", graphql_client_double(error=transport_error)
+    )
     connection = ApiConnectionGraphql(
         username="user@example.com",
         password="password",

--- a/tests/test_api_websocket.py
+++ b/tests/test_api_websocket.py
@@ -91,14 +91,20 @@ class FakeHeartbeatTask:
 class FakeListenerWebsocket:
     """Async websocket iterator for listener tests."""
 
-    def __init__(self, messages: list[SimpleNamespace]) -> None:
+    def __init__(
+        self,
+        messages: list[SimpleNamespace],
+        exception: BaseException | None = None,
+    ) -> None:
         """Initialize queued websocket messages.
 
         Args:
             messages: Messages yielded by the websocket iterator.
+            exception: Optional websocket error reported by ``exception``.
         """
         self.messages = messages
         self.closed = False
+        self.exception_value = exception
 
     def __aiter__(self) -> AsyncIterator[SimpleNamespace]:
         """Return this websocket as an async iterator.
@@ -124,6 +130,14 @@ class FakeListenerWebsocket:
     async def close(self) -> None:
         """Record websocket close requests."""
         self.closed = True
+
+    def exception(self) -> BaseException | None:
+        """Return the configured websocket exception.
+
+        Returns:
+            Optional websocket receive exception.
+        """
+        return self.exception_value
 
 
 class FakeWebsocketContext:
@@ -342,15 +356,37 @@ async def test_listener_does_not_wrap_callback_connection_errors() -> None:
 
 
 @pytest.mark.asyncio
-async def test_listener_breaks_on_websocket_error_message() -> None:
-    """Stop listening when the websocket yields an error message."""
+async def test_listener_raises_websocket_error_message_exception() -> None:
+    """Raise Carrier websocket errors when the websocket reports an exception."""
+    websocket_error = ClientConnectionError("websocket receive failed")
+    websocket = FakeListenerWebsocket(
+        [SimpleNamespace(type=WSMsgType.ERROR, data=None)], exception=websocket_error
+    )
+    connection = FakeListenerConnection(websocket)
+    heartbeat_task = FakeHeartbeatTask()
+    api_websocket = FakeHeartbeatApiWebsocket(connection, heartbeat_task)
+
+    with pytest.raises(CarrierApiWebsocketError) as error:
+        await api_websocket.listener()
+
+    assert error.value.__cause__ is websocket_error
+    assert heartbeat_task.cancelled
+    assert api_websocket.websocket is None
+    assert api_websocket.task_heartbeat is None
+
+
+@pytest.mark.asyncio
+async def test_listener_raises_websocket_error_message_without_exception() -> None:
+    """Raise Carrier websocket errors when aiohttp omits the underlying exception."""
     websocket = FakeListenerWebsocket([SimpleNamespace(type=WSMsgType.ERROR, data=None)])
     connection = FakeListenerConnection(websocket)
     heartbeat_task = FakeHeartbeatTask()
     api_websocket = FakeHeartbeatApiWebsocket(connection, heartbeat_task)
 
-    await api_websocket.listener()
+    with pytest.raises(CarrierApiWebsocketError) as error:
+        await api_websocket.listener()
 
+    assert error.value.__cause__ is None
     assert heartbeat_task.cancelled
     assert api_websocket.websocket is None
     assert api_websocket.task_heartbeat is None

--- a/tests/test_api_websocket.py
+++ b/tests/test_api_websocket.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from typing import cast
 
-from aiohttp import ClientConnectionError, ClientSession, WSMsgType
+from aiohttp import ClientConnectionError, ClientError, ClientSession, WSMsgType
 import pytest
 
 from carrier_api import ApiConnectionGraphql, ApiWebsocket, CarrierApiWebsocketError
@@ -191,7 +191,7 @@ class FakeListenerSession:
 class FailingListenerSession:
     """Session that fails websocket connection attempts."""
 
-    def __init__(self, error: ClientConnectionError) -> None:
+    def __init__(self, error: ClientError | TimeoutError | OSError) -> None:
         """Initialize the session with the error to raise.
 
         Args:
@@ -206,7 +206,8 @@ class FailingListenerSession:
             url: Websocket URL.
 
         Raises:
-            ClientConnectionError: Always raised for this failing session.
+            ClientError | TimeoutError | OSError: Always raised for this
+                failing session.
         """
         raise self.error
 
@@ -234,7 +235,7 @@ class FakeListenerConnection(DummyApiConnectionGraphql):
 class FailingListenerConnection(DummyApiConnectionGraphql):
     """Connection double with a failing websocket session."""
 
-    def __init__(self, error: ClientConnectionError) -> None:
+    def __init__(self, error: ClientError | TimeoutError | OSError) -> None:
         """Initialize fake connection state.
 
         Args:
@@ -311,9 +312,18 @@ async def test_listener_dispatches_text_and_closes_on_close_command() -> None:
 
 
 @pytest.mark.asyncio
-async def test_listener_wraps_websocket_connection_errors() -> None:
+@pytest.mark.parametrize(
+    "connection_error",
+    [
+        ClientConnectionError("websocket unavailable"),
+        TimeoutError("websocket timed out"),
+        OSError("websocket socket failed"),
+    ],
+)
+async def test_listener_wraps_websocket_connection_errors(
+    connection_error: ClientError | TimeoutError | OSError,
+) -> None:
     """Raise Carrier websocket errors instead of raw aiohttp connection errors."""
-    connection_error = ClientConnectionError("websocket unavailable")
     connection = FailingListenerConnection(connection_error)
     api_websocket = ApiWebsocket(connection)
 
@@ -325,13 +335,22 @@ async def test_listener_wraps_websocket_connection_errors() -> None:
 
 
 @pytest.mark.asyncio
-async def test_listener_does_not_wrap_callback_connection_errors() -> None:
+@pytest.mark.parametrize(
+    "callback_error",
+    [
+        ClientConnectionError("callback request failed"),
+        TimeoutError("callback timed out"),
+        OSError("callback socket failed"),
+    ],
+)
+async def test_listener_does_not_wrap_callback_connection_errors(
+    callback_error: ClientError | TimeoutError | OSError,
+) -> None:
     """Let callback I/O errors propagate instead of marking websocket failed."""
     websocket = FakeListenerWebsocket([SimpleNamespace(type=WSMsgType.TEXT, data="payload")])
     connection = FakeListenerConnection(websocket)
     heartbeat_task = FakeHeartbeatTask()
     api_websocket = FakeHeartbeatApiWebsocket(connection, heartbeat_task)
-    callback_error = ClientConnectionError("callback request failed")
 
     async def fail_callback(message: str) -> None:
         """Raise the configured callback I/O error.
@@ -340,13 +359,14 @@ async def test_listener_does_not_wrap_callback_connection_errors() -> None:
             message: Raw websocket text.
 
         Raises:
-            ClientConnectionError: Always raised for this callback.
+            ClientError | TimeoutError | OSError: Always raised for this
+                callback.
         """
         raise callback_error
 
     api_websocket.callback_add(fail_callback)
 
-    with pytest.raises(ClientConnectionError) as error:
+    with pytest.raises(type(callback_error)) as error:
         await api_websocket.listener()
 
     assert error.value is callback_error
@@ -358,7 +378,12 @@ async def test_listener_does_not_wrap_callback_connection_errors() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "websocket_error",
-    [ClientConnectionError("websocket receive failed"), None],
+    [
+        ClientConnectionError("websocket receive failed"),
+        TimeoutError("websocket receive timed out"),
+        OSError("websocket receive socket failed"),
+        None,
+    ],
 )
 async def test_listener_raises_websocket_error_messages(
     websocket_error: BaseException | None,

--- a/tests/test_api_websocket.py
+++ b/tests/test_api_websocket.py
@@ -356,9 +356,19 @@ async def test_listener_does_not_wrap_callback_connection_errors() -> None:
 
 
 @pytest.mark.asyncio
-async def test_listener_raises_websocket_error_message_exception() -> None:
-    """Raise Carrier websocket errors when the websocket reports an exception."""
-    websocket_error = ClientConnectionError("websocket receive failed")
+@pytest.mark.parametrize(
+    "websocket_error",
+    [ClientConnectionError("websocket receive failed"), None],
+)
+async def test_listener_raises_websocket_error_messages(
+    websocket_error: BaseException | None,
+) -> None:
+    """Raise Carrier websocket errors for websocket error messages.
+
+    Args:
+        websocket_error: Optional aiohttp websocket exception reported by the
+            fake websocket.
+    """
     websocket = FakeListenerWebsocket(
         [SimpleNamespace(type=WSMsgType.ERROR, data=None)], exception=websocket_error
     )
@@ -370,23 +380,6 @@ async def test_listener_raises_websocket_error_message_exception() -> None:
         await api_websocket.listener()
 
     assert error.value.__cause__ is websocket_error
-    assert heartbeat_task.cancelled
-    assert api_websocket.websocket is None
-    assert api_websocket.task_heartbeat is None
-
-
-@pytest.mark.asyncio
-async def test_listener_raises_websocket_error_message_without_exception() -> None:
-    """Raise Carrier websocket errors when aiohttp omits the underlying exception."""
-    websocket = FakeListenerWebsocket([SimpleNamespace(type=WSMsgType.ERROR, data=None)])
-    connection = FakeListenerConnection(websocket)
-    heartbeat_task = FakeHeartbeatTask()
-    api_websocket = FakeHeartbeatApiWebsocket(connection, heartbeat_task)
-
-    with pytest.raises(CarrierApiWebsocketError) as error:
-        await api_websocket.listener()
-
-    assert error.value.__cause__ is None
     assert heartbeat_task.cancelled
     assert api_websocket.websocket is None
     assert api_websocket.task_heartbeat is None

--- a/tests/test_api_websocket.py
+++ b/tests/test_api_websocket.py
@@ -311,6 +311,37 @@ async def test_listener_wraps_websocket_connection_errors() -> None:
 
 
 @pytest.mark.asyncio
+async def test_listener_does_not_wrap_callback_connection_errors() -> None:
+    """Let callback I/O errors propagate instead of marking websocket failed."""
+    websocket = FakeListenerWebsocket([SimpleNamespace(type=WSMsgType.TEXT, data="payload")])
+    connection = FakeListenerConnection(websocket)
+    heartbeat_task = FakeHeartbeatTask()
+    api_websocket = FakeHeartbeatApiWebsocket(connection, heartbeat_task)
+    callback_error = ClientConnectionError("callback request failed")
+
+    async def fail_callback(message: str) -> None:
+        """Raise the configured callback I/O error.
+
+        Args:
+            message: Raw websocket text.
+
+        Raises:
+            ClientConnectionError: Always raised for this callback.
+        """
+        raise callback_error
+
+    api_websocket.callback_add(fail_callback)
+
+    with pytest.raises(ClientConnectionError) as error:
+        await api_websocket.listener()
+
+    assert error.value is callback_error
+    assert heartbeat_task.cancelled
+    assert api_websocket.websocket is None
+    assert api_websocket.task_heartbeat is None
+
+
+@pytest.mark.asyncio
 async def test_listener_breaks_on_websocket_error_message() -> None:
     """Stop listening when the websocket yields an error message."""
     websocket = FakeListenerWebsocket([SimpleNamespace(type=WSMsgType.ERROR, data=None)])

--- a/tests/test_api_websocket.py
+++ b/tests/test_api_websocket.py
@@ -4,10 +4,10 @@ from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from typing import cast
 
-from aiohttp import ClientSession, WSMsgType
+from aiohttp import ClientConnectionError, ClientSession, WSMsgType
 import pytest
 
-from carrier_api import ApiConnectionGraphql, ApiWebsocket
+from carrier_api import ApiConnectionGraphql, ApiWebsocket, CarrierApiWebsocketError
 
 
 class DummyApiConnectionGraphql(ApiConnectionGraphql):
@@ -174,6 +174,29 @@ class FakeListenerSession:
         return FakeWebsocketContext(self.websocket)
 
 
+class FailingListenerSession:
+    """Session that fails websocket connection attempts."""
+
+    def __init__(self, error: ClientConnectionError) -> None:
+        """Initialize the session with the error to raise.
+
+        Args:
+            error: Connection error raised by ``ws_connect``.
+        """
+        self.error = error
+
+    def ws_connect(self, url: str) -> FakeWebsocketContext:
+        """Raise the configured websocket connection error.
+
+        Args:
+            url: Websocket URL.
+
+        Raises:
+            ClientConnectionError: Always raised for this failing session.
+        """
+        raise self.error
+
+
 class FakeListenerConnection(DummyApiConnectionGraphql):
     """Connection double with auth and websocket session behavior."""
 
@@ -186,6 +209,26 @@ class FakeListenerConnection(DummyApiConnectionGraphql):
         super().__init__()
         self.access_token = "token"
         self.listener_session = FakeListenerSession(websocket)
+        self.api_session = cast("ClientSession", self.listener_session)
+        self.auth_checked = False
+
+    async def check_auth_expiration(self) -> None:
+        """Record auth expiration checks."""
+        self.auth_checked = True
+
+
+class FailingListenerConnection(DummyApiConnectionGraphql):
+    """Connection double with a failing websocket session."""
+
+    def __init__(self, error: ClientConnectionError) -> None:
+        """Initialize fake connection state.
+
+        Args:
+            error: Connection error raised by the fake session.
+        """
+        super().__init__()
+        self.access_token = "token"
+        self.listener_session = FailingListenerSession(error)
         self.api_session = cast("ClientSession", self.listener_session)
         self.auth_checked = False
 
@@ -251,6 +294,20 @@ async def test_listener_dispatches_text_and_closes_on_close_command() -> None:
     assert heartbeat_task.cancelled
     assert api_websocket.websocket is None
     assert api_websocket.task_heartbeat is None
+
+
+@pytest.mark.asyncio
+async def test_listener_wraps_websocket_connection_errors() -> None:
+    """Raise Carrier websocket errors instead of raw aiohttp connection errors."""
+    connection_error = ClientConnectionError("websocket unavailable")
+    connection = FailingListenerConnection(connection_error)
+    api_websocket = ApiWebsocket(connection)
+
+    with pytest.raises(CarrierApiWebsocketError) as error:
+        await api_websocket.listener()
+
+    assert connection.auth_checked
+    assert error.value.__cause__ is connection_error
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Normalizes Carrier API failure handling behind CarrierApi* exceptions so consumers can catch this library's errors without importing gql or aiohttp exception types.

## What Changed
- Added CarrierApi-prefixed exception classes and deprecated compatibility aliases.
- Normalized GraphQL, auth, token refresh, websocket, timeout, and OS-level connection failures to Carrier API exceptions.
- Preserved original exceptions as causes and retained auth failure payloads for debugging.
- Updated README guidance and expanded regression coverage for normalized error paths.
- Kept live smoke test error handling aligned with the new exception model.

## Why
Downstream integrations such as ha_carrier should be able to handle Carrier API failures through this package's public exception surface instead of depending on transport-library exceptions.

## Validation
- `./.venv/bin/pytest`
- `./.venv/bin/mypy`
- `./.venv/bin/ruff check src tests`
- `./.venv/bin/prek run --all-files`