### PR TITLE
Add zone profile and HVAC capability helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,14 @@ Model objects provide `as_dict()` for structured serialization. Their string and
 - `supports_fan()`
 - `supported_hvac_capabilities()`
 
-For zone-level profile resolution, call `ConfigZone.current_status_activity(status_zone)` with the matching `StatusZone` from the same system. This uses Carrier's reported current activity from live status data. Use `ConfigZone.current_scheduled_activity()` when you want the activity implied by schedule and hold configuration instead. `System.as_dict()` performs the status/config pairing for the aggregate system.
+For zone-level profile resolution, call `ConfigZone.current_status_activity(status_zone)` with matching zones from the same system. This uses Carrier's reported current activity type from live status data. Use `ConfigZone.current_scheduled_activity()` when you want the activity implied by schedule and hold configuration instead.
+
+Deprecated compatibility aliases:
+
+- `StatusZone.current_activity` is an alias for `StatusZone.current_status_activity_type`. It returns Carrier's live status-derived activity type/name.
+- `ConfigZone.current_activity()` is an alias for `ConfigZone.current_scheduled_activity()`. It returns the schedule/configuration-derived activity.
+
+To get both activity sources together, use `ConfigZone.as_dict(status_zone)["current_activity"]` or `System.as_dict()["config"]["zones"][...]["current_activity"]`. That object has `from_schedule` and `from_status` keys. `System.as_dict()` performs the status/config pairing for the aggregate system.
 
 `System.as_dict()` includes `supported_hvac_capabilities` and passes status-zone context into config serialization so each zone dictionary includes `current_activity.from_schedule` and `current_activity.from_status`.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Model objects provide `as_dict()` for structured serialization. Their string and
 - `supports_fan()`
 - `supported_hvac_capabilities()`
 
-For zone-level profile resolution, call `ConfigZone.current_status_activity(status_zone)` with the matching `StatusZone`. This uses Carrier's reported current activity from live status data. Use `ConfigZone.current_scheduled_activity()` when you want the activity implied by schedule and hold configuration instead.
+For zone-level profile resolution, call `ConfigZone.current_status_activity(status_zone)` with the matching `StatusZone` from the same system. This uses Carrier's reported current activity from live status data. Use `ConfigZone.current_scheduled_activity()` when you want the activity implied by schedule and hold configuration instead. `System.as_dict()` performs the status/config pairing for the aggregate system.
 
 `System.as_dict()` includes `supported_hvac_capabilities` and passes status-zone context into config serialization so each zone dictionary includes `current_activity.from_schedule` and `current_activity.from_status`.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Model objects provide `as_dict()` for structured serialization. Their string and
 - `supports_fan()`
 - `supported_hvac_capabilities()`
 
-For zone-level profile resolution, call `ConfigZone.current_status_activity(status_zone)` with the matching `StatusZone`. This uses Carrier's reported current activity when the zone is not held, and the configured hold activity when a hold is active.
+For zone-level profile resolution, call `ConfigZone.current_status_activity(status_zone)` with the matching `StatusZone`. This uses Carrier's reported current activity from live status data. Use `ConfigZone.current_scheduled_activity()` when you want the activity implied by schedule and hold configuration instead.
 
 `System.as_dict()` includes `supported_hvac_capabilities` and passes status-zone context into config serialization so each zone dictionary includes `current_activity.from_schedule` and `current_activity.from_status`.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Model objects provide `as_dict()` for structured serialization. Their string and
 
 For zone-level profile resolution, call `ConfigZone.current_status_activity(status_zone)` with the matching `StatusZone`. This uses Carrier's reported current activity when the zone is not held, and the configured hold activity when a hold is active.
 
-`System.as_dict()` includes `supported_hvac_capabilities` and passes status-zone context into config serialization so each zone dictionary includes `current_status_activity`.
+`System.as_dict()` includes `supported_hvac_capabilities` and passes status-zone context into config serialization so each zone dictionary includes `current_activity.from_schedule` and `current_activity.from_status`.
 
 ## Updating Thermostat Settings
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Model objects provide `as_dict()` for structured serialization. Their string and
 
 For zone-level profile resolution, call `ConfigZone.current_status_activity(status_zone)` with the matching `StatusZone`. This uses Carrier's reported current activity when the zone is not held, and the configured hold activity when a hold is active.
 
+`System.as_dict()` includes `supported_hvac_capabilities` and passes status-zone context into config serialization so each zone dictionary includes `current_status_activity`.
+
 ## Updating Thermostat Settings
 
 Mutation helpers send Carrier configuration updates and then request websocket reconciliation when a websocket manager is available.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ asyncio.run(main())
 
 Model objects provide `as_dict()` for structured serialization. Their string and repr forms are intended for readable debugging output.
 
+`System` also exposes HVAC capability helpers:
+
+- `supports_heat()`
+- `supports_cool()`
+- `supports_fan()`
+- `supported_hvac_capabilities()`
+
+For zone-level profile resolution, call `ConfigZone.current_status_activity(status_zone)` with the matching `StatusZone`. This uses Carrier's reported current activity when the zone is not held, and the configured hold activity when a hold is active.
+
 ## Updating Thermostat Settings
 
 Mutation helpers send Carrier configuration updates and then request websocket reconciliation when a websocket manager is available.

--- a/src/carrier_api/config.py
+++ b/src/carrier_api/config.py
@@ -164,7 +164,7 @@ class ConfigZone:
         reversed_active_periods = reversed(self.today_active_periods())
         for active_period in reversed_active_periods:
             hours, minutes = active_period["time"].split(":")
-            if (int(hours) < now.hour) or (int(hours) == now.hour and int(minutes) < now.minute):
+            if (int(hours) < now.hour) or (int(hours) == now.hour and int(minutes) <= now.minute):
                 return self.find_activity(
                     safely_get_json_value(active_period, "activity", ActivityTypes)
                 )

--- a/src/carrier_api/config.py
+++ b/src/carrier_api/config.py
@@ -203,9 +203,11 @@ class ConfigZone:
 
         Returns:
             The configured activity matching the status/hold activity, or
-            ``None`` when that activity is missing from this zone's
-            configuration.
+            ``None`` when the status belongs to a different zone or that
+            activity is missing from this zone's configuration.
         """
+        if status_zone.api_id != self.api_id:
+            return None
         return self.find_activity(status_zone.current_status_activity)
 
     def next_activity_time(self) -> str | None:
@@ -314,7 +316,8 @@ class Config:
         self.etag = safely_get_json_value(self.raw, "etag")
         self.fuel_type = safely_get_json_value(self.raw, "fueltype")
         self.gas_unit = safely_get_json_value(self.raw, "gasunit")
-        self.fan_enabled = safely_get_json_value(self.raw, "cfgfan") == "on"
+        raw_fan_enabled = safely_get_json_value(self.raw, "cfgfan")
+        self.fan_enabled = None if raw_fan_enabled is None else raw_fan_enabled == "on"
         self.uv_enabled = safely_get_json_value(self.raw, "cfguv") == "on"
         self.humidifier_enabled = safely_get_json_value(self.raw, "cfghumid") == "on"
         self.humidifier_heat_target = safely_get_json_value(self.raw, "humidityHome.rhtg", int)

--- a/src/carrier_api/config.py
+++ b/src/carrier_api/config.py
@@ -150,7 +150,7 @@ class ConfigZone:
         yet.
 
         Use ``current_status_activity`` when resolving Carrier's live
-        ``StatusZone.current_status_activity`` report instead of the local
+        ``StatusZone.current_status_activity_type`` report instead of the local
         schedule calculation.
 
         Returns:
@@ -178,13 +178,18 @@ class ConfigZone:
     def current_activity(self) -> ConfigZoneActivity | None:
         """Return the schedule-derived current activity.
 
-        This method is a compatibility alias for
-        ``current_scheduled_activity``. Prefer ``current_scheduled_activity``
-        for new code so it is clear the value is computed from local schedule
-        and hold configuration, not Carrier's live status payload.
+        Deprecated:
+            Use ``current_scheduled_activity`` instead. This alias returns the
+            schedule-derived value; it does not return Carrier's
+            live status activity and it does not return the combined
+            ``{"from_schedule": ..., "from_status": ...}`` serialization.
+
+        Use ``as_dict(status_zone)["current_activity"]`` or
+        ``System.as_dict()["config"]["zones"][...]["current_activity"]`` when
+        both schedule-derived and status-derived activity profiles are needed.
 
         Returns:
-            The activity profile implied by schedule/configuration data, or
+            The activity profile implied by schedule data, or
             ``None`` when no active period is available.
         """
         return self.current_scheduled_activity()
@@ -193,7 +198,7 @@ class ConfigZone:
         """Return the activity profile matching Carrier's live status report.
 
         This is status-derived and always resolves the
-        ``StatusZone.current_status_activity`` value Carrier reported for the
+        ``StatusZone.current_status_activity_type`` value Carrier reported for the
         matching zone. It intentionally does not consult local hold state
         because config and status updates can arrive separately.
 
@@ -210,7 +215,7 @@ class ConfigZone:
         """
         if status_zone.api_id != self.api_id:
             return None
-        return self.find_activity(status_zone.current_status_activity)
+        return self.find_activity(status_zone.current_status_activity_type)
 
     def next_activity_time(self) -> str | None:
         """Find the next scheduled activity start time.
@@ -238,7 +243,9 @@ class ConfigZone:
         Args:
             status_zone: Optional runtime status for this zone. When provided,
                 ``current_activity.from_status`` resolves Carrier's live status
-                activity; when omitted, that field is ``None``.
+                activity; when omitted, that field is ``None``. The
+                ``current_activity.from_schedule`` value is always derived from
+                local schedule/hold configuration.
 
         Returns:
             A dictionary containing hold state, occupancy configuration,

--- a/src/carrier_api/config.py
+++ b/src/carrier_api/config.py
@@ -140,17 +140,23 @@ class ConfigZone:
         today_schedule_json = self.program_json["day"][sunday_0_index_today]
         return active_schedule_periods(today_schedule_json["period"])
 
-    def current_activity(self) -> ConfigZoneActivity | None:
-        """Determine the zone activity that should currently be active.
+    def current_scheduled_activity(self) -> ConfigZoneActivity | None:
+        """Determine the zone activity implied by local schedule configuration.
 
-        Held zones resolve directly to their hold activity. Scheduled zones use
-        the latest enabled period earlier than the current local time, falling
-        back to yesterday's final enabled period when today's schedule has not
-        started yet.
+        This is schedule/configuration-derived. Held zones resolve directly to
+        their configured hold activity. Non-held zones use the latest enabled
+        schedule period earlier than the current local time, falling back to
+        yesterday's final enabled period when today's schedule has not started
+        yet.
+
+        Use ``current_status_activity`` when resolving Carrier's live
+        ``StatusZone.current_status_activity`` report instead of the local
+        schedule calculation.
 
         Returns:
-            The configured current activity, or ``None`` when no active period is
-            available in today or yesterday's schedule.
+            The activity profile implied by schedule/configuration data, or
+            ``None`` when no active period is available in today or yesterday's
+            schedule.
         """
         if self.hold:
             return self.find_activity(self.hold_activity)
@@ -170,18 +176,23 @@ class ConfigZone:
         )
 
     def current_status_activity(self, status_zone: StatusZone) -> ConfigZoneActivity | None:
-        """Return the activity profile currently reported for a status zone.
+        """Return the activity profile matching Carrier's live status report.
+
+        This is status-derived. For non-held zones, it resolves the
+        ``StatusZone.current_status_activity`` value Carrier reported for the
+        matching zone. For held zones, it resolves the configured hold activity
+        so local hold state remains authoritative for the selected profile.
 
         Args:
-            status_zone: Runtime zone status containing Carrier's current
-                activity value.
+            status_zone: Runtime zone status containing Carrier's reported
+                current activity value.
 
         Returns:
-            The configured activity matching the current runtime status, or
-            ``None`` when Carrier reports an activity missing from this zone's
+            The configured activity matching the status/hold activity, or
+            ``None`` when that activity is missing from this zone's
             configuration.
         """
-        activity_type = self.hold_activity if self.hold else status_zone.current_activity
+        activity_type = self.hold_activity if self.hold else status_zone.current_status_activity
         return self.find_activity(activity_type)
 
     def next_activity_time(self) -> str | None:
@@ -209,24 +220,29 @@ class ConfigZone:
 
         Args:
             status_zone: Optional runtime status for this zone. When provided,
-                the dictionary includes the activity profile Carrier reports as
-                currently active.
+                ``current_activity.from_status`` resolves Carrier's live status
+                activity; when omitted, that field is ``None``.
 
         Returns:
-            A dictionary containing hold state, occupancy configuration, current
-            activity, and configured activities.
+            A dictionary containing hold state, occupancy configuration,
+            configured activities, and ``current_activity`` split into
+            ``from_schedule`` and ``from_status`` sources.
         """
-        current_activity = self.current_activity()
+        current_scheduled_activity = self.current_scheduled_activity()
         current_status_activity = (
             self.current_status_activity(status_zone) if status_zone is not None else None
         )
         builder = {
             "api_id": self.api_id,
             "name": self.name,
-            "current_activity": current_activity.as_dict() if current_activity else None,
-            "current_status_activity": current_status_activity.as_dict()
-            if current_status_activity
-            else None,
+            "current_activity": {
+                "from_schedule": current_scheduled_activity.as_dict()
+                if current_scheduled_activity
+                else None,
+                "from_status": current_status_activity.as_dict()
+                if current_status_activity
+                else None,
+            },
             "hold_activity": self.hold_activity,
             "hold": self.hold,
             "hold_until": self.hold_until,

--- a/src/carrier_api/config.py
+++ b/src/carrier_api/config.py
@@ -199,7 +199,9 @@ class ConfigZone:
 
         Args:
             status_zone: Runtime zone status containing Carrier's reported
-                current activity value.
+                current activity value. This must come from the same Carrier
+                system as this config zone; status zones do not include system
+                identity, so this method can only validate the zone ID.
 
         Returns:
             The configured activity matching the status/hold activity, or
@@ -340,6 +342,7 @@ class Config:
         Args:
             status_zones: Optional runtime status zones used to include
                 status-resolved current activity profiles in zone dictionaries.
+                These must come from the same Carrier system as this config.
 
         Returns:
             A dictionary containing high-level settings and enabled zones.

--- a/src/carrier_api/config.py
+++ b/src/carrier_api/config.py
@@ -175,13 +175,27 @@ class ConfigZone:
             safely_get_json_value(yesterday_active_periods[-1], "activity", ActivityTypes)
         )
 
+    def current_activity(self) -> ConfigZoneActivity | None:
+        """Return the schedule-derived current activity.
+
+        This method is a compatibility alias for
+        ``current_scheduled_activity``. Prefer ``current_scheduled_activity``
+        for new code so it is clear the value is computed from local schedule
+        and hold configuration, not Carrier's live status payload.
+
+        Returns:
+            The activity profile implied by schedule/configuration data, or
+            ``None`` when no active period is available.
+        """
+        return self.current_scheduled_activity()
+
     def current_status_activity(self, status_zone: StatusZone) -> ConfigZoneActivity | None:
         """Return the activity profile matching Carrier's live status report.
 
-        This is status-derived. For non-held zones, it resolves the
+        This is status-derived and always resolves the
         ``StatusZone.current_status_activity`` value Carrier reported for the
-        matching zone. For held zones, it resolves the configured hold activity
-        so local hold state remains authoritative for the selected profile.
+        matching zone. It intentionally does not consult local hold state
+        because config and status updates can arrive separately.
 
         Args:
             status_zone: Runtime zone status containing Carrier's reported
@@ -192,8 +206,7 @@ class ConfigZone:
             ``None`` when that activity is missing from this zone's
             configuration.
         """
-        activity_type = self.hold_activity if self.hold else status_zone.current_status_activity
-        return self.find_activity(activity_type)
+        return self.find_activity(status_zone.current_status_activity)
 
     def next_activity_time(self) -> str | None:
         """Find the next scheduled activity start time.
@@ -279,6 +292,7 @@ class Config:
     etag: str | None = None
     fuel_type: str | None = None
     gas_unit: str | None = None
+    fan_enabled: bool | None = None
     zones: list[ConfigZone]
     uv_enabled: bool | None = None
     humidifier_enabled: bool | None = None
@@ -300,6 +314,7 @@ class Config:
         self.etag = safely_get_json_value(self.raw, "etag")
         self.fuel_type = safely_get_json_value(self.raw, "fueltype")
         self.gas_unit = safely_get_json_value(self.raw, "gasunit")
+        self.fan_enabled = safely_get_json_value(self.raw, "cfgfan") == "on"
         self.uv_enabled = safely_get_json_value(self.raw, "cfguv") == "on"
         self.humidifier_enabled = safely_get_json_value(self.raw, "cfghumid") == "on"
         self.humidifier_heat_target = safely_get_json_value(self.raw, "humidityHome.rhtg", int)
@@ -331,6 +346,7 @@ class Config:
             "temperature_unit": self.temperature_unit,
             "mode": self.mode,
             "heat_source": self.heat_source,
+            "fan_enabled": self.fan_enabled,
             "zones": [
                 zone.as_dict(status_zones_by_id.get(zone.api_id)) for zone in self.zones or []
             ],

--- a/src/carrier_api/config.py
+++ b/src/carrier_api/config.py
@@ -2,10 +2,13 @@
 
 from datetime import UTC, datetime
 from logging import getLogger
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .const import ActivityTypes, FanModes
 from .util import safely_get_json_value
+
+if TYPE_CHECKING:
+    from .status import StatusZone
 
 _LOGGER = getLogger(__name__)
 
@@ -165,6 +168,21 @@ class ConfigZone:
         return self.find_activity(
             safely_get_json_value(yesterday_active_periods[-1], "activity", ActivityTypes)
         )
+
+    def current_status_activity(self, status_zone: StatusZone) -> ConfigZoneActivity | None:
+        """Return the activity profile currently reported for a status zone.
+
+        Args:
+            status_zone: Runtime zone status containing Carrier's current
+                activity value.
+
+        Returns:
+            The configured activity matching the current runtime status, or
+            ``None`` when Carrier reports an activity missing from this zone's
+            configuration.
+        """
+        activity_type = self.hold_activity if self.hold else status_zone.current_activity
+        return self.find_activity(activity_type)
 
     def next_activity_time(self) -> str | None:
         """Find the next scheduled activity start time.

--- a/src/carrier_api/config.py
+++ b/src/carrier_api/config.py
@@ -204,18 +204,29 @@ class ConfigZone:
             return tomorrow_active_schedule_periods[0]["time"]
         return None
 
-    def as_dict(self) -> dict[str, Any]:
+    def as_dict(self, status_zone: StatusZone | None = None) -> dict[str, Any]:
         """Return a dictionary representation of the zone configuration.
+
+        Args:
+            status_zone: Optional runtime status for this zone. When provided,
+                the dictionary includes the activity profile Carrier reports as
+                currently active.
 
         Returns:
             A dictionary containing hold state, occupancy configuration, current
             activity, and configured activities.
         """
         current_activity = self.current_activity()
+        current_status_activity = (
+            self.current_status_activity(status_zone) if status_zone is not None else None
+        )
         builder = {
             "api_id": self.api_id,
             "name": self.name,
             "current_activity": current_activity.as_dict() if current_activity else None,
+            "current_status_activity": current_status_activity.as_dict()
+            if current_status_activity
+            else None,
             "hold_activity": self.hold_activity,
             "hold": self.hold,
             "hold_until": self.hold_until,
@@ -289,17 +300,24 @@ class Config:
             if safely_get_json_value(zone_json, "enabled") == "on":
                 self.zones.append(ConfigZone(zone_json=zone_json, vacation_json=vacation_json))
 
-    def as_dict(self) -> dict[str, Any]:
+    def as_dict(self, status_zones: list[StatusZone] | None = None) -> dict[str, Any]:
         """Return a dictionary representation of the system configuration.
+
+        Args:
+            status_zones: Optional runtime status zones used to include
+                status-resolved current activity profiles in zone dictionaries.
 
         Returns:
             A dictionary containing high-level settings and enabled zones.
         """
+        status_zones_by_id = {status_zone.api_id: status_zone for status_zone in status_zones or []}
         return {
             "temperature_unit": self.temperature_unit,
             "mode": self.mode,
             "heat_source": self.heat_source,
-            "zones": [zone.as_dict() for zone in self.zones or []],
+            "zones": [
+                zone.as_dict(status_zones_by_id.get(zone.api_id)) for zone in self.zones or []
+            ],
         }
 
     def __repr__(self) -> str:

--- a/src/carrier_api/status.py
+++ b/src/carrier_api/status.py
@@ -13,7 +13,7 @@ _LOGGER = getLogger(__name__)
 
 
 class StatusZone:
-    """Runtime status for a single Carrier zone."""
+    """Runtime status reported by Carrier for a single zone."""
 
     def __init__(self, status_zone_json: dict[str, Any]) -> None:
         """Build zone status from a Carrier status zone payload.
@@ -23,7 +23,9 @@ class StatusZone:
         """
         self.api_id = safely_get_json_value(status_zone_json, "id", str)
         self.name: str = safely_get_json_value(status_zone_json, "name")
-        self.current_activity: ActivityTypes = ActivityTypes(status_zone_json["currentActivity"])
+        self.current_status_activity: ActivityTypes = ActivityTypes(
+            status_zone_json["currentActivity"]
+        )
         self.temperature: float = safely_get_json_value(status_zone_json, "rt", float)
         self.humidity: int = safely_get_json_value(status_zone_json, "rh", int)
         self.occupancy: bool = safely_get_json_value(status_zone_json, "occupancy") == "occupied"
@@ -63,7 +65,7 @@ class StatusZone:
         return {
             "id": self.api_id,
             "name": self.name,
-            "current_activity": self.current_activity.value,
+            "current_status_activity": self.current_status_activity.value,
             "temperature": self.temperature,
             "humidity": self.humidity,
             "fan": self.fan.value,

--- a/src/carrier_api/status.py
+++ b/src/carrier_api/status.py
@@ -23,7 +23,10 @@ class StatusZone:
         """
         self.api_id = safely_get_json_value(status_zone_json, "id", str)
         self.name: str = safely_get_json_value(status_zone_json, "name")
-        self.current_status_activity: ActivityTypes = ActivityTypes(
+        # This is only Carrier's reported activity type. Use
+        # ConfigZone.current_status_activity(status_zone) to resolve the full
+        # activity profile with fan mode and heat/cool set points.
+        self.current_status_activity_type: ActivityTypes = ActivityTypes(
             status_zone_json["currentActivity"]
         )
         self.temperature: float = safely_get_json_value(status_zone_json, "rt", float)
@@ -41,24 +44,32 @@ class StatusZone:
     def current_activity(self) -> ActivityTypes:
         """Return Carrier's live current activity report.
 
-        This property is a compatibility alias for
-        ``current_status_activity``. Prefer ``current_status_activity`` for new
-        code so this runtime value is not confused with the schedule-derived
-        ``ConfigZone.current_scheduled_activity`` helper.
+        Deprecated:
+            Use ``current_status_activity_type`` instead. This alias returns the
+            same Carrier status-derived value; it does not return the
+            schedule-derived activity or the combined ``current_activity``
+            serialization from ``ConfigZone.as_dict()``.
+
+        This property remains as a compatibility alias for integrations that
+        still read ``StatusZone.current_activity``.
 
         Returns:
             Carrier's reported current activity for this status zone.
         """
-        return self.current_status_activity
+        return self.current_status_activity_type
 
     @current_activity.setter
     def current_activity(self, value: ActivityTypes) -> None:
         """Set Carrier's live current activity through the compatibility alias.
 
+        Deprecated:
+            Assign ``current_status_activity_type`` instead. This setter updates
+            the same status-derived value as ``current_status_activity_type``.
+
         Args:
             value: Activity type to store as the status-derived current activity.
         """
-        self.current_status_activity = value
+        self.current_status_activity_type = value
 
     @property
     def zone_conditioning_const(self) -> SystemModes:
@@ -88,8 +99,7 @@ class StatusZone:
         return {
             "id": self.api_id,
             "name": self.name,
-            "current_activity": self.current_status_activity.value,
-            "current_status_activity": self.current_status_activity.value,
+            "current_status_activity_type": self.current_status_activity_type.value,
             "temperature": self.temperature,
             "humidity": self.humidity,
             "fan": self.fan.value,

--- a/src/carrier_api/status.py
+++ b/src/carrier_api/status.py
@@ -38,6 +38,20 @@ class StatusZone:
         self.damper_position: int = safely_get_json_value(status_zone_json, "damperposition", int)
 
     @property
+    def current_activity(self) -> ActivityTypes:
+        """Return Carrier's live current activity report.
+
+        This property is a compatibility alias for
+        ``current_status_activity``. Prefer ``current_status_activity`` for new
+        code so this runtime value is not confused with the schedule-derived
+        ``ConfigZone.current_scheduled_activity`` helper.
+
+        Returns:
+            Carrier's reported current activity for this status zone.
+        """
+        return self.current_status_activity
+
+    @property
     def zone_conditioning_const(self) -> SystemModes:
         """Map Carrier zone conditioning text to a system mode constant.
 
@@ -65,6 +79,7 @@ class StatusZone:
         return {
             "id": self.api_id,
             "name": self.name,
+            "current_activity": self.current_status_activity.value,
             "current_status_activity": self.current_status_activity.value,
             "temperature": self.temperature,
             "humidity": self.humidity,

--- a/src/carrier_api/status.py
+++ b/src/carrier_api/status.py
@@ -51,6 +51,15 @@ class StatusZone:
         """
         return self.current_status_activity
 
+    @current_activity.setter
+    def current_activity(self, value: ActivityTypes) -> None:
+        """Set Carrier's live current activity through the compatibility alias.
+
+        Args:
+            value: Activity type to store as the status-derived current activity.
+        """
+        self.current_status_activity = value
+
     @property
     def zone_conditioning_const(self) -> SystemModes:
         """Map Carrier zone conditioning text to a system mode constant.

--- a/src/carrier_api/system.py
+++ b/src/carrier_api/system.py
@@ -13,18 +13,10 @@ _LOGGER = getLogger(__name__)
 HEAT_CAPABILITY_FIELDS = ("electric_heat", "gas", "hp_heat", "loop_pump", "reheat")
 COOL_CAPABILITY_FIELDS = ("cooling", "loop_pump")
 FAN_CAPABILITY_FIELDS = ("fan", "fan_gas")
-HEAT_PROFILE_FIELDS = ("indoor_unit_source", "indoor_unit_type", "outdoor_unit_type")
-COOL_PROFILE_FIELDS = ("outdoor_unit_type",)
-HEAT_PROFILE_TOKENS = (
-    "electric",
-    "fan coil",
-    "fancoil",
-    "furnace",
-    "gas",
-    "heat",
-    "hp",
-)
-COOL_PROFILE_TOKENS = ("ac", "cool", "hp")
+HEAT_INDOOR_SOURCES = ("electric", "gas")
+HEAT_INDOOR_TYPES = ("fan coil", "fancoil", "furnace")
+HEAT_OUTDOOR_TYPE_PREFIXES = ("hp", "heatpump")
+COOL_OUTDOOR_TYPE_PREFIXES = ("ac", "hp", "cool", "heatpump")
 
 
 class System:
@@ -57,7 +49,7 @@ class System:
             ``True`` when equipment metadata or energy configuration indicates
             the system has a heat-capable component.
         """
-        return self._profile_contains_any(HEAT_PROFILE_FIELDS, HEAT_PROFILE_TOKENS) or (
+        return self._profile_supports_heat() or (
             self._supports_any_energy_capability(HEAT_CAPABILITY_FIELDS)
         )
 
@@ -68,7 +60,7 @@ class System:
             ``True`` when equipment metadata or energy configuration indicates
             the system has a cool-capable component.
         """
-        return self._profile_contains_any(COOL_PROFILE_FIELDS, COOL_PROFILE_TOKENS) or (
+        return self._profile_supports_cool() or (
             self._supports_any_energy_capability(COOL_CAPABILITY_FIELDS)
         )
 
@@ -110,23 +102,45 @@ class System:
             for capability_field in capability_fields
         )
 
-    def _profile_contains_any(
-        self, profile_fields: tuple[str, ...], capability_tokens: tuple[str, ...]
-    ) -> bool:
-        """Return whether profile equipment metadata contains capability hints.
-
-        Args:
-            profile_fields: Profile attribute names to inspect.
-            capability_tokens: Case-insensitive substrings that imply support.
+    def _profile_supports_heat(self) -> bool:
+        """Return whether profile equipment metadata reports known heat hardware.
 
         Returns:
-            ``True`` when any named profile field contains a capability token.
+            ``True`` when Carrier profile fields identify a heat-capable indoor
+            or outdoor unit.
         """
-        return any(
-            capability_token in str(getattr(self.profile, profile_field, "")).lower()
-            for profile_field in profile_fields
-            for capability_token in capability_tokens
+        indoor_source = self._normalized_profile_value("indoor_unit_source")
+        indoor_type = self._normalized_profile_value("indoor_unit_type")
+        outdoor_type = self._normalized_profile_value("outdoor_unit_type")
+        return (
+            indoor_source in HEAT_INDOOR_SOURCES
+            or indoor_type in HEAT_INDOOR_TYPES
+            or outdoor_type.startswith(HEAT_OUTDOOR_TYPE_PREFIXES)
         )
+
+    def _profile_supports_cool(self) -> bool:
+        """Return whether profile equipment metadata reports known cool hardware.
+
+        Returns:
+            ``True`` when Carrier profile fields identify a cool-capable
+            outdoor unit.
+        """
+        outdoor_type = self._normalized_profile_value("outdoor_unit_type")
+        return outdoor_type.startswith(COOL_OUTDOOR_TYPE_PREFIXES)
+
+    def _normalized_profile_value(self, profile_field: str) -> str:
+        """Return a normalized profile field value for exact/prefix matching.
+
+        Args:
+            profile_field: Profile attribute name to inspect.
+
+        Returns:
+            A lower-case, stripped string value, or an empty string when absent.
+        """
+        value = getattr(self.profile, profile_field, None)
+        if value is None:
+            return ""
+        return str(value).strip().lower()
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of the aggregate.

--- a/src/carrier_api/system.py
+++ b/src/carrier_api/system.py
@@ -43,10 +43,15 @@ class System:
         self.config = config
 
     def supports_heat(self) -> bool:
-        """Return whether the system reports heating capability.
+        """Return whether available Carrier data suggests heating support.
+
+        Carrier does not expose these profile fields as typed capability enums.
+        This helper combines known energy reporting flags with best-effort
+        equipment metadata hints, so it should be treated as a practical support
+        signal rather than an authoritative equipment/control contract.
 
         Returns:
-            ``True`` when equipment metadata or energy configuration indicates
+            ``True`` when equipment metadata or energy configuration suggests
             the system has a heat-capable component.
         """
         return self._profile_supports_heat() or (
@@ -54,10 +59,15 @@ class System:
         )
 
     def supports_cool(self) -> bool:
-        """Return whether the system reports cooling capability.
+        """Return whether available Carrier data suggests cooling support.
+
+        Carrier does not expose these profile fields as typed capability enums.
+        This helper combines known energy reporting flags with best-effort
+        equipment metadata hints, so it should be treated as a practical support
+        signal rather than an authoritative equipment/control contract.
 
         Returns:
-            ``True`` when equipment metadata or energy configuration indicates
+            ``True`` when equipment metadata or energy configuration suggests
             the system has a cool-capable component.
         """
         return self._profile_supports_cool() or (
@@ -65,22 +75,30 @@ class System:
         )
 
     def supports_fan(self) -> bool:
-        """Return whether the system reports fan-only capability.
+        """Return whether available Carrier data suggests fan support.
+
+        Carrier does not expose a typed fan capability enum here. This helper
+        treats the config fan setting as authoritative when Carrier provides
+        it. Energy reporting flags are only used as a fallback when the config
+        payload omits a fan control flag.
 
         Returns:
-            ``True`` when configuration or energy data indicates fan control is
-            available.
+            ``True`` when configuration indicates fan control is available, or
+            when energy data reports fan support and configuration has no fan
+            control flag.
         """
-        return (self.config.fan_enabled is True) or (
-            self._supports_any_energy_capability(FAN_CAPABILITY_FIELDS)
-        )
+        if self.config.fan_enabled is not None:
+            return self.config.fan_enabled
+        return self._supports_any_energy_capability(FAN_CAPABILITY_FIELDS)
 
     def supported_hvac_capabilities(self) -> dict[str, bool]:
-        """Return supported heat, cool, and fan controls.
+        """Return best-effort heat, cool, and fan support signals.
 
         Returns:
-            A dictionary containing boolean support flags for ``heat``,
-            ``cool``, and ``fan``.
+            A dictionary containing boolean support signals for ``heat``,
+            ``cool``, and ``fan`` derived from Carrier profile, config, and
+            energy data. These are not guaranteed to be authoritative control
+            capabilities.
         """
         return {
             "heat": self.supports_heat(),
@@ -103,11 +121,11 @@ class System:
         )
 
     def _profile_supports_heat(self) -> bool:
-        """Return whether profile equipment metadata reports known heat hardware.
+        """Return whether profile metadata matches known heat-capable values.
 
         Returns:
-            ``True`` when Carrier profile fields identify a heat-capable indoor
-            or outdoor unit.
+            ``True`` when Carrier profile string fields match values currently
+            known to imply heat-capable indoor or outdoor hardware.
         """
         indoor_source = self._normalized_profile_value("indoor_unit_source")
         indoor_type = self._normalized_profile_value("indoor_unit_type")
@@ -119,11 +137,11 @@ class System:
         )
 
     def _profile_supports_cool(self) -> bool:
-        """Return whether profile equipment metadata reports known cool hardware.
+        """Return whether profile metadata matches known cool-capable values.
 
         Returns:
-            ``True`` when Carrier profile fields identify a cool-capable
-            outdoor unit.
+            ``True`` when Carrier profile string fields match values currently
+            known to imply cool-capable outdoor hardware.
         """
         outdoor_type = self._normalized_profile_value("outdoor_unit_type")
         return outdoor_type.startswith(COOL_OUTDOOR_TYPE_PREFIXES)

--- a/src/carrier_api/system.py
+++ b/src/carrier_api/system.py
@@ -13,6 +13,18 @@ _LOGGER = getLogger(__name__)
 HEAT_CAPABILITY_FIELDS = ("electric_heat", "gas", "hp_heat", "loop_pump", "reheat")
 COOL_CAPABILITY_FIELDS = ("cooling", "loop_pump")
 FAN_CAPABILITY_FIELDS = ("fan", "fan_gas")
+HEAT_PROFILE_FIELDS = ("indoor_unit_source", "indoor_unit_type", "outdoor_unit_type")
+COOL_PROFILE_FIELDS = ("outdoor_unit_type",)
+HEAT_PROFILE_TOKENS = (
+    "electric",
+    "fan coil",
+    "fancoil",
+    "furnace",
+    "gas",
+    "heat",
+    "hp",
+)
+COOL_PROFILE_TOKENS = ("ac", "cool", "hp")
 
 
 class System:
@@ -42,28 +54,34 @@ class System:
         """Return whether the system reports heating capability.
 
         Returns:
-            ``True`` when any parsed heating energy capability is displayable
-            and enabled.
+            ``True`` when equipment metadata or energy configuration indicates
+            the system has a heat-capable component.
         """
-        return self._supports_any_energy_capability(HEAT_CAPABILITY_FIELDS)
+        return self._profile_contains_any(HEAT_PROFILE_FIELDS, HEAT_PROFILE_TOKENS) or (
+            self._supports_any_energy_capability(HEAT_CAPABILITY_FIELDS)
+        )
 
     def supports_cool(self) -> bool:
         """Return whether the system reports cooling capability.
 
         Returns:
-            ``True`` when any parsed cooling energy capability is displayable
-            and enabled.
+            ``True`` when equipment metadata or energy configuration indicates
+            the system has a cool-capable component.
         """
-        return self._supports_any_energy_capability(COOL_CAPABILITY_FIELDS)
+        return self._profile_contains_any(COOL_PROFILE_FIELDS, COOL_PROFILE_TOKENS) or (
+            self._supports_any_energy_capability(COOL_CAPABILITY_FIELDS)
+        )
 
     def supports_fan(self) -> bool:
         """Return whether the system reports fan-only capability.
 
         Returns:
-            ``True`` when any parsed fan energy capability is displayable and
-            enabled.
+            ``True`` when configuration or energy data indicates fan control is
+            available.
         """
-        return self._supports_any_energy_capability(FAN_CAPABILITY_FIELDS)
+        return (self.config.fan_enabled is True) or (
+            self._supports_any_energy_capability(FAN_CAPABILITY_FIELDS)
+        )
 
     def supported_hvac_capabilities(self) -> dict[str, bool]:
         """Return supported heat, cool, and fan controls.
@@ -90,6 +108,24 @@ class System:
         return any(
             getattr(self.energy, capability_field, False) is True
             for capability_field in capability_fields
+        )
+
+    def _profile_contains_any(
+        self, profile_fields: tuple[str, ...], capability_tokens: tuple[str, ...]
+    ) -> bool:
+        """Return whether profile equipment metadata contains capability hints.
+
+        Args:
+            profile_fields: Profile attribute names to inspect.
+            capability_tokens: Case-insensitive substrings that imply support.
+
+        Returns:
+            ``True`` when any named profile field contains a capability token.
+        """
+        return any(
+            capability_token in str(getattr(self.profile, profile_field, "")).lower()
+            for profile_field in profile_fields
+            for capability_token in capability_tokens
         )
 
     def as_dict(self) -> dict[str, Any]:

--- a/src/carrier_api/system.py
+++ b/src/carrier_api/system.py
@@ -10,6 +10,10 @@ from .status import Status
 
 _LOGGER = getLogger(__name__)
 
+HEAT_CAPABILITY_FIELDS = ("electric_heat", "gas", "hp_heat", "loop_pump", "reheat")
+COOL_CAPABILITY_FIELDS = ("cooling", "loop_pump")
+FAN_CAPABILITY_FIELDS = ("fan", "fan_gas")
+
 
 class System:
     """Carrier system composed from profile, status, config, and energy data."""
@@ -33,6 +37,60 @@ class System:
         self.status = status
         self.energy = energy
         self.config = config
+
+    def supports_heat(self) -> bool:
+        """Return whether the system reports heating capability.
+
+        Returns:
+            ``True`` when any parsed heating energy capability is displayable
+            and enabled.
+        """
+        return self._supports_any_energy_capability(HEAT_CAPABILITY_FIELDS)
+
+    def supports_cool(self) -> bool:
+        """Return whether the system reports cooling capability.
+
+        Returns:
+            ``True`` when any parsed cooling energy capability is displayable
+            and enabled.
+        """
+        return self._supports_any_energy_capability(COOL_CAPABILITY_FIELDS)
+
+    def supports_fan(self) -> bool:
+        """Return whether the system reports fan-only capability.
+
+        Returns:
+            ``True`` when any parsed fan energy capability is displayable and
+            enabled.
+        """
+        return self._supports_any_energy_capability(FAN_CAPABILITY_FIELDS)
+
+    def supported_hvac_capabilities(self) -> dict[str, bool]:
+        """Return supported heat, cool, and fan controls.
+
+        Returns:
+            A dictionary containing boolean support flags for ``heat``,
+            ``cool``, and ``fan``.
+        """
+        return {
+            "heat": self.supports_heat(),
+            "cool": self.supports_cool(),
+            "fan": self.supports_fan(),
+        }
+
+    def _supports_any_energy_capability(self, capability_fields: tuple[str, ...]) -> bool:
+        """Return whether any named energy capability is enabled.
+
+        Args:
+            capability_fields: Energy model attribute names to inspect.
+
+        Returns:
+            ``True`` when any named capability is exactly ``True``.
+        """
+        return any(
+            getattr(self.energy, capability_field, False) is True
+            for capability_field in capability_fields
+        )
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of the aggregate.

--- a/src/carrier_api/system.py
+++ b/src/carrier_api/system.py
@@ -4,7 +4,6 @@ from logging import getLogger
 from typing import Any
 
 from .config import Config
-from .const import FanModes
 from .energy import Energy
 from .profile import Profile
 from .status import Status
@@ -14,10 +13,6 @@ _LOGGER = getLogger(__name__)
 HEAT_CAPABILITY_FIELDS = ("electric_heat", "gas", "hp_heat", "loop_pump", "reheat")
 COOL_CAPABILITY_FIELDS = ("cooling", "loop_pump")
 FAN_CAPABILITY_FIELDS = ("fan", "fan_gas")
-HEAT_INDOOR_SOURCES = ("electric", "gas")
-HEAT_INDOOR_TYPES = ("fan coil", "fancoil", "furnace")
-HEAT_OUTDOOR_TYPE_PREFIXES = ("hp", "heatpump")
-COOL_OUTDOOR_TYPE_PREFIXES = ("ac", "hp", "cool", "heatpump")
 
 
 class System:
@@ -44,44 +39,41 @@ class System:
         self.config = config
 
     def supports_heat(self) -> bool:
-        """Return whether available Carrier data suggests heating support.
+        """Return whether Carrier energy data reports heating support.
 
-        Carrier does not expose these profile fields as typed capability enums.
-        This helper combines known energy reporting flags with best-effort
-        equipment metadata hints, so it should be treated as a practical support
-        signal rather than an authoritative equipment/control contract.
+        Carrier's captured profile fields do not expose typed HVAC capability
+        enums, and the raw ``idutype``/``odutype`` values are free-form strings
+        in the GraphQL schema. This helper intentionally uses parsed
+        ``energyConfig`` flags only, so treat it as a best-effort reported
+        support signal rather than an authoritative equipment/control contract.
 
         Returns:
-            ``True`` when equipment metadata or energy configuration suggests
-            the system has a heat-capable component.
+            ``True`` when any parsed heating energy capability is displayable
+            and enabled.
         """
-        return self._profile_supports_heat() or (
-            self._supports_any_energy_capability(HEAT_CAPABILITY_FIELDS)
-        )
+        return self._supports_any_energy_capability(HEAT_CAPABILITY_FIELDS)
 
     def supports_cool(self) -> bool:
-        """Return whether available Carrier data suggests cooling support.
+        """Return whether Carrier energy data reports cooling support.
 
-        Carrier does not expose these profile fields as typed capability enums.
-        This helper combines known energy reporting flags with best-effort
-        equipment metadata hints, so it should be treated as a practical support
-        signal rather than an authoritative equipment/control contract.
+        Carrier's captured profile fields do not expose typed HVAC capability
+        enums, and the raw ``idutype``/``odutype`` values are free-form strings
+        in the GraphQL schema. This helper intentionally uses parsed
+        ``energyConfig`` flags only, so treat it as a best-effort reported
+        support signal rather than an authoritative equipment/control contract.
 
         Returns:
-            ``True`` when equipment metadata or energy configuration suggests
-            the system has a cool-capable component.
+            ``True`` when any parsed cooling energy capability is displayable
+            and enabled.
         """
-        return self._profile_supports_cool() or (
-            self._supports_any_energy_capability(COOL_CAPABILITY_FIELDS)
-        )
+        return self._supports_any_energy_capability(COOL_CAPABILITY_FIELDS)
 
     def supports_fan(self) -> bool:
         """Return whether available Carrier data suggests fan support.
 
         Carrier does not expose a typed fan capability enum here. This helper
         treats the config fan flag as authoritative when Carrier provides it.
-        Activity fan modes and energy reporting flags are only fallbacks when
-        that flag is omitted.
+        Energy reporting flags are only a fallback when that flag is omitted.
 
         Returns:
             ``True`` when configuration or energy data suggests fan control is
@@ -89,8 +81,6 @@ class System:
         """
         if self.config.fan_enabled is not None:
             return self.config.fan_enabled
-        if self._config_supports_fan_control():
-            return True
         return self._supports_any_energy_capability(FAN_CAPABILITY_FIELDS)
 
     def supported_hvac_capabilities(self) -> dict[str, bool]:
@@ -98,9 +88,8 @@ class System:
 
         Returns:
             A dictionary containing boolean support signals for ``heat``,
-            ``cool``, and ``fan`` derived from Carrier profile, config, and
-            energy data. These are not guaranteed to be authoritative control
-            capabilities.
+            ``cool``, and ``fan`` derived from Carrier config and energy data.
+            These are not guaranteed to be authoritative control capabilities.
         """
         return {
             "heat": self.supports_heat(),
@@ -121,58 +110,6 @@ class System:
             getattr(self.energy, capability_field, False) is True
             for capability_field in capability_fields
         )
-
-    def _config_supports_fan_control(self) -> bool:
-        """Return whether zone activities expose fan control values.
-
-        Returns:
-            ``True`` when any configured activity has a parsed non-off fan mode.
-        """
-        return any(
-            activity.fan is not None and activity.fan is not FanModes.OFF
-            for zone in self.config.zones or []
-            for activity in zone.activities or []
-        )
-
-    def _profile_supports_heat(self) -> bool:
-        """Return whether profile metadata matches known heat-capable values.
-
-        Returns:
-            ``True`` when Carrier profile string fields match values currently
-            known to imply heat-capable indoor or outdoor hardware.
-        """
-        indoor_source = self._normalized_profile_value("indoor_unit_source")
-        indoor_type = self._normalized_profile_value("indoor_unit_type")
-        outdoor_type = self._normalized_profile_value("outdoor_unit_type")
-        return (
-            indoor_source in HEAT_INDOOR_SOURCES
-            or indoor_type in HEAT_INDOOR_TYPES
-            or outdoor_type.startswith(HEAT_OUTDOOR_TYPE_PREFIXES)
-        )
-
-    def _profile_supports_cool(self) -> bool:
-        """Return whether profile metadata matches known cool-capable values.
-
-        Returns:
-            ``True`` when Carrier profile string fields match values currently
-            known to imply cool-capable outdoor hardware.
-        """
-        outdoor_type = self._normalized_profile_value("outdoor_unit_type")
-        return outdoor_type.startswith(COOL_OUTDOOR_TYPE_PREFIXES)
-
-    def _normalized_profile_value(self, profile_field: str) -> str:
-        """Return a normalized profile field value for exact/prefix matching.
-
-        Args:
-            profile_field: Profile attribute name to inspect.
-
-        Returns:
-            A lower-case, stripped string value, or an empty string when absent.
-        """
-        value = getattr(self.profile, profile_field, None)
-        if value is None:
-            return ""
-        return str(value).strip().lower()
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of the aggregate.

--- a/src/carrier_api/system.py
+++ b/src/carrier_api/system.py
@@ -4,6 +4,7 @@ from logging import getLogger
 from typing import Any
 
 from .config import Config
+from .const import FanModes
 from .energy import Energy
 from .profile import Profile
 from .status import Status
@@ -78,13 +79,16 @@ class System:
         """Return whether available Carrier data suggests fan support.
 
         Carrier does not expose a typed fan capability enum here. This helper
-        uses configured zone activity fan controls first. Energy reporting
-        flags are only a fallback when no activity fan data is available.
+        treats the config fan flag as authoritative when Carrier provides it.
+        Activity fan modes and energy reporting flags are only fallbacks when
+        that flag is omitted.
 
         Returns:
             ``True`` when configuration or energy data suggests fan control is
             available.
         """
+        if self.config.fan_enabled is not None:
+            return self.config.fan_enabled
         if self._config_supports_fan_control():
             return True
         return self._supports_any_energy_capability(FAN_CAPABILITY_FIELDS)
@@ -122,10 +126,10 @@ class System:
         """Return whether zone activities expose fan control values.
 
         Returns:
-            ``True`` when any configured activity has a parsed fan mode.
+            ``True`` when any configured activity has a parsed non-off fan mode.
         """
         return any(
-            activity.fan is not None
+            activity.fan is not None and activity.fan is not FanModes.OFF
             for zone in self.config.zones or []
             for activity in zone.activities or []
         )

--- a/src/carrier_api/system.py
+++ b/src/carrier_api/system.py
@@ -78,17 +78,15 @@ class System:
         """Return whether available Carrier data suggests fan support.
 
         Carrier does not expose a typed fan capability enum here. This helper
-        treats the config fan setting as authoritative when Carrier provides
-        it. Energy reporting flags are only used as a fallback when the config
-        payload omits a fan control flag.
+        uses configured zone activity fan controls first. Energy reporting
+        flags are only a fallback when no activity fan data is available.
 
         Returns:
-            ``True`` when configuration indicates fan control is available, or
-            when energy data reports fan support and configuration has no fan
-            control flag.
+            ``True`` when configuration or energy data suggests fan control is
+            available.
         """
-        if self.config.fan_enabled is not None:
-            return self.config.fan_enabled
+        if self._config_supports_fan_control():
+            return True
         return self._supports_any_energy_capability(FAN_CAPABILITY_FIELDS)
 
     def supported_hvac_capabilities(self) -> dict[str, bool]:
@@ -118,6 +116,18 @@ class System:
         return any(
             getattr(self.energy, capability_field, False) is True
             for capability_field in capability_fields
+        )
+
+    def _config_supports_fan_control(self) -> bool:
+        """Return whether zone activities expose fan control values.
+
+        Returns:
+            ``True`` when any configured activity has a parsed fan mode.
+        """
+        return any(
+            activity.fan is not None
+            for zone in self.config.zones or []
+            for activity in zone.activities or []
         )
 
     def _profile_supports_heat(self) -> bool:

--- a/src/carrier_api/system.py
+++ b/src/carrier_api/system.py
@@ -103,8 +103,9 @@ class System:
             "name": self.profile.name,
             "profile": self.profile.as_dict(),
             "status": self.status.as_dict(),
-            "config": self.config.as_dict(),
+            "config": self.config.as_dict(self.status.zones),
             "energy": self.energy.as_dict(),
+            "supported_hvac_capabilities": self.supported_hvac_capabilities(),
         }
 
     def __repr__(self) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,41 @@
 """Tests for configuration schedule behavior."""
 
+from datetime import datetime, tzinfo
+from typing import Self
+
+import pytest
+
+from carrier_api import config as config_module
 from carrier_api.config import ConfigZone
+from carrier_api.const import ActivityTypes
 
 
-def test_current_scheduled_activity_returns_none_when_no_periods_are_active() -> None:
-    """Return no scheduled activity when today and yesterday have no active periods."""
-    zone = ConfigZone(
+class FixedDateTime(datetime):
+    """Fixed datetime provider for schedule boundary tests."""
+
+    @classmethod
+    def now(cls, tz: tzinfo | None = None) -> Self:
+        """Return a stable local schedule time.
+
+        Args:
+            tz: Optional timezone requested by production code.
+
+        Returns:
+            A fixed aware datetime at 08:30.
+        """
+        return cls(2026, 5, 26, 8, 30, tzinfo=tz)
+
+
+def build_zone_with_periods(periods: list[dict[str, str]]) -> ConfigZone:
+    """Build a config zone with the same periods on every schedule day.
+
+    Args:
+        periods: Schedule periods to repeat across all seven days.
+
+    Returns:
+        A config zone using the supplied schedule periods.
+    """
+    return ConfigZone(
         zone_json={
             "id": "1",
             "name": "Zone 1",
@@ -22,20 +52,7 @@ def test_current_scheduled_activity_returns_none_when_no_periods_are_active() ->
                     "clsp": "72",
                 }
             ],
-            "program": {
-                "day": [
-                    {
-                        "period": [
-                            {
-                                "enabled": "off",
-                                "time": "00:00",
-                                "activity": "home",
-                            }
-                        ]
-                    }
-                    for _ in range(7)
-                ]
-            },
+            "program": {"day": [{"period": periods} for _ in range(7)]},
         },
         vacation_json={
             "type": "vacation",
@@ -45,4 +62,38 @@ def test_current_scheduled_activity_returns_none_when_no_periods_are_active() ->
         },
     )
 
+
+def test_current_scheduled_activity_returns_none_when_no_periods_are_active() -> None:
+    """Return no scheduled activity when today and yesterday have no active periods."""
+    zone = build_zone_with_periods(
+        [
+            {
+                "enabled": "off",
+                "time": "00:00",
+                "activity": "home",
+            }
+        ]
+    )
+
     assert zone.current_scheduled_activity() is None
+
+
+def test_current_scheduled_activity_includes_period_start_minute(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use the starting activity when the current time equals a period time."""
+    monkeypatch.setattr(config_module, "datetime", FixedDateTime)
+    zone = build_zone_with_periods(
+        [
+            {
+                "enabled": "on",
+                "time": "08:30",
+                "activity": "home",
+            }
+        ]
+    )
+
+    current_scheduled_activity = zone.current_scheduled_activity()
+
+    assert current_scheduled_activity is not None
+    assert current_scheduled_activity.type == ActivityTypes.HOME

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,9 +21,11 @@ class FixedDateTime(datetime):
             tz: Optional timezone requested by production code.
 
         Returns:
-            A fixed aware datetime at 08:30.
+            A fixed datetime whose local wall-clock time is 08:30 after
+            production converts it through ``astimezone()``.
         """
-        return cls(2026, 5, 26, 8, 30, tzinfo=tz)
+        timestamp = datetime(2026, 5, 26, 8, 30).astimezone().timestamp()
+        return cls.fromtimestamp(timestamp, tz)
 
 
 def build_zone_with_periods(periods: list[dict[str, str]]) -> ConfigZone:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,8 +3,8 @@
 from carrier_api.config import ConfigZone
 
 
-def test_current_activity_returns_none_when_no_periods_are_active() -> None:
-    """Return no current activity when today and yesterday have no active periods."""
+def test_current_scheduled_activity_returns_none_when_no_periods_are_active() -> None:
+    """Return no scheduled activity when today and yesterday have no active periods."""
     zone = ConfigZone(
         zone_json={
             "id": "1",
@@ -45,4 +45,4 @@ def test_current_activity_returns_none_when_no_periods_are_active() -> None:
         },
     )
 
-    assert zone.current_activity() is None
+    assert zone.current_scheduled_activity() is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -333,22 +333,21 @@ def test_system_reports_supported_hvac_capabilities_from_equipment_and_config(
     }
 
 
-def test_system_hvac_capabilities_ignore_ambiguous_profile_strings(
+def test_system_hvac_capabilities_ignore_profile_equipment_strings(
     system_response: dict[str, Any],
     energy_response: dict[str, Any],
 ) -> None:
-    """Avoid reporting support from incidental profile substrings.
+    """Avoid reporting heat/cool support from free-form profile strings.
 
     Args:
         system_response: Parsed systems fixture.
         energy_response: Parsed energy fixture.
     """
     raw_system = deepcopy(system_response["infinitySystems"][0])
-    raw_system["profile"]["idutype"] = "package"
-    raw_system["profile"]["idusource"] = "none"
-    raw_system["profile"]["odutype"] = "package"
+    raw_system["profile"]["idutype"] = "furnace"
+    raw_system["profile"]["idusource"] = "gas"
+    raw_system["profile"]["odutype"] = "ac2stg"
     raw_system["config"]["cfgfan"] = "off"
-    raw_system["config"]["zones"] = []
     raw_energy = deepcopy(energy_response["infinityEnergy"])
     for energy_config in raw_energy["energyConfig"].values():
         if isinstance(energy_config, dict):
@@ -378,17 +377,17 @@ def test_system_hvac_capabilities_do_not_let_activity_fan_override_cfgfan_off(
     """
     system = systems[0]
     system.config.fan_enabled = False
-    system.energy.fan = False
-    system.energy.fan_gas = False
+    system.energy.fan = True
+    system.energy.fan_gas = True
 
     assert not system.supports_fan()
     assert not system.supported_hvac_capabilities()["fan"]
 
 
-def test_system_hvac_capabilities_fall_back_to_activity_fan_controls(
+def test_system_hvac_capabilities_fall_back_to_energy_fan_flags(
     systems: list[System],
 ) -> None:
-    """Use configured activity fan modes when cfgfan is absent.
+    """Use energy fan flags when cfgfan is absent.
 
     Args:
         systems: Prepared system fixture models.
@@ -397,6 +396,10 @@ def test_system_hvac_capabilities_fall_back_to_activity_fan_controls(
     system.config.fan_enabled = None
     system.energy.fan = False
     system.energy.fan_gas = False
+
+    assert not system.supports_fan()
+
+    system.energy.fan = True
 
     assert system.supports_fan()
     assert system.supported_hvac_capabilities()["fan"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -347,6 +347,7 @@ def test_system_hvac_capabilities_ignore_ambiguous_profile_strings(
     raw_system["profile"]["idutype"] = "package"
     raw_system["profile"]["idusource"] = "none"
     raw_system["profile"]["odutype"] = "package"
+    raw_system["config"]["cfgfan"] = "off"
     raw_system["config"]["zones"] = []
     raw_energy = deepcopy(energy_response["infinityEnergy"])
     for energy_config in raw_energy["energyConfig"].values():
@@ -367,16 +368,33 @@ def test_system_hvac_capabilities_ignore_ambiguous_profile_strings(
     }
 
 
-def test_system_hvac_capabilities_use_activity_fan_controls_when_cfgfan_is_off(
+def test_system_hvac_capabilities_do_not_let_activity_fan_override_cfgfan_off(
     systems: list[System],
 ) -> None:
-    """Treat configured activity fan modes as stronger fan support evidence.
+    """Treat cfgfan as authoritative when Carrier provides that flag.
 
     Args:
         systems: Prepared system fixture models.
     """
     system = systems[0]
     system.config.fan_enabled = False
+    system.energy.fan = False
+    system.energy.fan_gas = False
+
+    assert not system.supports_fan()
+    assert not system.supported_hvac_capabilities()["fan"]
+
+
+def test_system_hvac_capabilities_fall_back_to_activity_fan_controls(
+    systems: list[System],
+) -> None:
+    """Use configured activity fan modes when cfgfan is absent.
+
+    Args:
+        systems: Prepared system fixture models.
+    """
+    system = systems[0]
+    system.config.fan_enabled = None
     system.energy.fan = False
     system.energy.fan_gas = False
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -137,6 +137,7 @@ def test_config_schedule_branches_and_serialization(system_response: dict[str, A
     assert zone.next_activity_time() is not None
     assert config.humidifier_heat_target == 35
     assert config.as_dict()["zones"][0]["activities"][-1]["type"] == "vacation"
+    assert config.as_dict()["zones"][0]["current_status_activity"] is None
     assert repr(config) == str(config.as_dict())
     assert str(zone) == str(zone.as_dict())
 
@@ -160,6 +161,7 @@ def test_config_zone_current_activity_from_status_uses_api_reported_profile(
     assert current_activity is not None
     assert current_activity.type == ActivityTypes.WAKE
     assert current_activity is zone.find_activity(ActivityTypes.WAKE)
+    assert zone.as_dict(status_zone)["current_status_activity"] == current_activity.as_dict()
 
 
 def test_config_zone_current_activity_from_status_prefers_hold_activity(
@@ -263,8 +265,9 @@ def test_system_as_dict_uses_nested_model_dictionaries(
 
     assert system.as_dict()["profile"] == system.profile.as_dict()
     assert system.as_dict()["status"] == system.status.as_dict()
-    assert system.as_dict()["config"] == system.config.as_dict()
+    assert system.as_dict()["config"] == system.config.as_dict(system.status.zones)
     assert system.as_dict()["energy"] == system.energy.as_dict()
+    assert system.as_dict()["config"]["zones"][0]["current_status_activity"]["type"] == "wake"
     assert repr(system) == str(system.as_dict())
 
 
@@ -282,6 +285,11 @@ def test_system_reports_supported_hvac_capabilities(
     assert system.supports_cool()
     assert not system.supports_fan()
     assert system.supported_hvac_capabilities() == {
+        "heat": True,
+        "cool": True,
+        "fan": False,
+    }
+    assert system.as_dict()["supported_hvac_capabilities"] == {
         "heat": True,
         "cool": True,
         "fan": False,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -347,7 +347,7 @@ def test_system_hvac_capabilities_ignore_ambiguous_profile_strings(
     raw_system["profile"]["idutype"] = "package"
     raw_system["profile"]["idusource"] = "none"
     raw_system["profile"]["odutype"] = "package"
-    raw_system["config"]["cfgfan"] = "off"
+    raw_system["config"]["zones"] = []
     raw_energy = deepcopy(energy_response["infinityEnergy"])
     for energy_config in raw_energy["energyConfig"].values():
         if isinstance(energy_config, dict):
@@ -367,21 +367,21 @@ def test_system_hvac_capabilities_ignore_ambiguous_profile_strings(
     }
 
 
-def test_system_hvac_capabilities_do_not_let_energy_override_config_fan_off(
+def test_system_hvac_capabilities_use_activity_fan_controls_when_cfgfan_is_off(
     systems: list[System],
 ) -> None:
-    """Treat config fan control as authoritative over fan energy telemetry.
+    """Treat configured activity fan modes as stronger fan support evidence.
 
     Args:
         systems: Prepared system fixture models.
     """
     system = systems[0]
     system.config.fan_enabled = False
-    system.energy.fan = True
-    system.energy.fan_gas = True
+    system.energy.fan = False
+    system.energy.fan_gas = False
 
-    assert not system.supports_fan()
-    assert not system.supported_hvac_capabilities()["fan"]
+    assert system.supports_fan()
+    assert system.supported_hvac_capabilities()["fan"]
 
 
 def test_safely_get_json_value_handles_nested_lists_none_and_cast_failures() -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -85,6 +85,8 @@ def test_status_modes_zone_conditioning_and_serialization(
     assert heat_status.mode_const == SystemModes.HEAT
     assert status.zones[0].zone_conditioning_const == SystemModes.HEAT
     assert status.zones[0].current_status_activity == ActivityTypes.WAKE
+    assert status.zones[0].current_activity == ActivityTypes.WAKE
+    assert status.zones[0].as_dict()["current_activity"] == "wake"
     assert status.zones[0].as_dict()["current_status_activity"] == "wake"
     assert status.as_dict()["time_stamp"] == datetime(2025, 3, 3, 13, 42, 34, 328000, UTC)
     assert status.as_dict()["uv_lamp_level"] == 100
@@ -135,6 +137,7 @@ def test_config_schedule_branches_and_serialization(system_response: dict[str, A
     assert zone.today_active_periods()
     assert zone.yesterday_active_periods()
     assert zone.current_scheduled_activity() is not None
+    assert zone.current_activity() is zone.current_scheduled_activity()
     assert held_zone.current_scheduled_activity() is held_zone.find_activity(ActivityTypes.MANUAL)
     assert zone.next_activity_time() is not None
     assert config.humidifier_heat_target == 35
@@ -171,10 +174,10 @@ def test_config_zone_current_activity_from_status_uses_api_reported_profile(
     }
 
 
-def test_config_zone_current_activity_from_status_prefers_hold_activity(
+def test_config_zone_current_activity_from_status_uses_status_when_config_hold_lags(
     system_response: dict[str, Any],
 ) -> None:
-    """Resolve held zones through the configured hold profile.
+    """Resolve status activity from status data even when config hold state lags.
 
     Args:
         system_response: Parsed systems fixture.
@@ -192,7 +195,7 @@ def test_config_zone_current_activity_from_status_prefers_hold_activity(
     current_status_activity = zone.current_status_activity(status.zones[0])
 
     assert current_status_activity is not None
-    assert current_status_activity.type == ActivityTypes.MANUAL
+    assert current_status_activity.type == ActivityTypes.WAKE
 
 
 def test_config_zone_current_activity_from_status_returns_none_for_missing_profile(
@@ -280,10 +283,10 @@ def test_system_as_dict_uses_nested_model_dictionaries(
     assert repr(system) == str(system.as_dict())
 
 
-def test_system_reports_supported_hvac_capabilities(
+def test_system_reports_supported_hvac_capabilities_from_equipment_and_config(
     systems: list[System],
 ) -> None:
-    """Expose supported heat, cool, and fan controls from energy config.
+    """Expose supported heat, cool, and fan controls from best-known raw data.
 
     Args:
         systems: Prepared system fixture models.
@@ -292,16 +295,16 @@ def test_system_reports_supported_hvac_capabilities(
 
     assert system.supports_heat()
     assert system.supports_cool()
-    assert not system.supports_fan()
+    assert system.supports_fan()
     assert system.supported_hvac_capabilities() == {
         "heat": True,
         "cool": True,
-        "fan": False,
+        "fan": True,
     }
     assert system.as_dict()["supported_hvac_capabilities"] == {
         "heat": True,
         "cool": True,
-        "fan": False,
+        "fan": True,
     }
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -141,6 +141,71 @@ def test_config_schedule_branches_and_serialization(system_response: dict[str, A
     assert str(zone) == str(zone.as_dict())
 
 
+def test_config_zone_current_activity_from_status_uses_api_reported_profile(
+    system_response: dict[str, Any],
+) -> None:
+    """Resolve the current activity profile from Carrier status data.
+
+    Args:
+        system_response: Parsed systems fixture.
+    """
+    raw_system = system_response["infinitySystems"][0]
+    config = Config(raw_system["config"])
+    status = Status(raw_system["status"])
+    zone = config.zones[0]
+    status_zone = status.zones[0]
+
+    current_activity = zone.current_status_activity(status_zone)
+
+    assert current_activity is not None
+    assert current_activity.type == ActivityTypes.WAKE
+    assert current_activity is zone.find_activity(ActivityTypes.WAKE)
+
+
+def test_config_zone_current_activity_from_status_prefers_hold_activity(
+    system_response: dict[str, Any],
+) -> None:
+    """Resolve held zones through the configured hold profile.
+
+    Args:
+        system_response: Parsed systems fixture.
+    """
+    raw_system = system_response["infinitySystems"][0]
+    raw_config = deepcopy(raw_system["config"])
+    raw_status = deepcopy(raw_system["status"])
+    raw_config["zones"][0]["hold"] = "on"
+    raw_config["zones"][0]["holdActivity"] = "manual"
+    raw_status["zones"][0]["currentActivity"] = "wake"
+    config = Config(raw_config)
+    status = Status(raw_status)
+    zone = config.zones[0]
+
+    current_activity = zone.current_status_activity(status.zones[0])
+
+    assert current_activity is not None
+    assert current_activity.type == ActivityTypes.MANUAL
+
+
+def test_config_zone_current_activity_from_status_returns_none_for_missing_profile(
+    system_response: dict[str, Any],
+) -> None:
+    """Return no profile when Carrier reports an activity not present in config.
+
+    Args:
+        system_response: Parsed systems fixture.
+    """
+    raw_system = system_response["infinitySystems"][0]
+    raw_config = deepcopy(raw_system["config"])
+    raw_status = deepcopy(raw_system["status"])
+    raw_config["zones"][0]["activities"] = [
+        activity for activity in raw_config["zones"][0]["activities"] if activity["type"] != "wake"
+    ]
+    config = Config(raw_config)
+    status = Status(raw_status)
+
+    assert config.zones[0].current_status_activity(status.zones[0]) is None
+
+
 def test_config_next_activity_time_returns_none_when_today_and_tomorrow_are_disabled() -> None:
     """Return no next activity time when today and tomorrow have no enabled periods."""
     zone = ConfigZone(
@@ -201,6 +266,26 @@ def test_system_as_dict_uses_nested_model_dictionaries(
     assert system.as_dict()["config"] == system.config.as_dict()
     assert system.as_dict()["energy"] == system.energy.as_dict()
     assert repr(system) == str(system.as_dict())
+
+
+def test_system_reports_supported_hvac_capabilities(
+    systems: list[System],
+) -> None:
+    """Expose supported heat, cool, and fan controls from energy config.
+
+    Args:
+        systems: Prepared system fixture models.
+    """
+    system = systems[0]
+
+    assert system.supports_heat()
+    assert system.supports_cool()
+    assert not system.supports_fan()
+    assert system.supported_hvac_capabilities() == {
+        "heat": True,
+        "cool": True,
+        "fan": False,
+    }
 
 
 def test_safely_get_json_value_handles_nested_lists_none_and_cast_failures() -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -84,6 +84,8 @@ def test_status_modes_zone_conditioning_and_serialization(
 
     assert heat_status.mode_const == SystemModes.HEAT
     assert status.zones[0].zone_conditioning_const == SystemModes.HEAT
+    assert status.zones[0].current_status_activity == ActivityTypes.WAKE
+    assert status.zones[0].as_dict()["current_status_activity"] == "wake"
     assert status.as_dict()["time_stamp"] == datetime(2025, 3, 3, 13, 42, 34, 328000, UTC)
     assert status.as_dict()["uv_lamp_level"] == 100
     assert repr(status.zones[0]) == str(status.zones[0].as_dict())
@@ -132,12 +134,12 @@ def test_config_schedule_branches_and_serialization(system_response: dict[str, A
     assert zone.find_activity(ActivityTypes.MANUAL) is not None
     assert zone.today_active_periods()
     assert zone.yesterday_active_periods()
-    assert zone.current_activity() is not None
-    assert held_zone.current_activity() is held_zone.find_activity(ActivityTypes.MANUAL)
+    assert zone.current_scheduled_activity() is not None
+    assert held_zone.current_scheduled_activity() is held_zone.find_activity(ActivityTypes.MANUAL)
     assert zone.next_activity_time() is not None
     assert config.humidifier_heat_target == 35
     assert config.as_dict()["zones"][0]["activities"][-1]["type"] == "vacation"
-    assert config.as_dict()["zones"][0]["current_status_activity"] is None
+    assert config.as_dict()["zones"][0]["current_activity"]["from_status"] is None
     assert repr(config) == str(config.as_dict())
     assert str(zone) == str(zone.as_dict())
 
@@ -156,12 +158,17 @@ def test_config_zone_current_activity_from_status_uses_api_reported_profile(
     zone = config.zones[0]
     status_zone = status.zones[0]
 
-    current_activity = zone.current_status_activity(status_zone)
+    current_status_activity = zone.current_status_activity(status_zone)
 
-    assert current_activity is not None
-    assert current_activity.type == ActivityTypes.WAKE
-    assert current_activity is zone.find_activity(ActivityTypes.WAKE)
-    assert zone.as_dict(status_zone)["current_status_activity"] == current_activity.as_dict()
+    assert current_status_activity is not None
+    current_scheduled_activity = zone.current_scheduled_activity()
+    assert current_scheduled_activity is not None
+    assert current_status_activity.type == ActivityTypes.WAKE
+    assert current_status_activity is zone.find_activity(ActivityTypes.WAKE)
+    assert zone.as_dict(status_zone)["current_activity"] == {
+        "from_schedule": current_scheduled_activity.as_dict(),
+        "from_status": current_status_activity.as_dict(),
+    }
 
 
 def test_config_zone_current_activity_from_status_prefers_hold_activity(
@@ -182,10 +189,10 @@ def test_config_zone_current_activity_from_status_prefers_hold_activity(
     status = Status(raw_status)
     zone = config.zones[0]
 
-    current_activity = zone.current_status_activity(status.zones[0])
+    current_status_activity = zone.current_status_activity(status.zones[0])
 
-    assert current_activity is not None
-    assert current_activity.type == ActivityTypes.MANUAL
+    assert current_status_activity is not None
+    assert current_status_activity.type == ActivityTypes.MANUAL
 
 
 def test_config_zone_current_activity_from_status_returns_none_for_missing_profile(
@@ -267,7 +274,9 @@ def test_system_as_dict_uses_nested_model_dictionaries(
     assert system.as_dict()["status"] == system.status.as_dict()
     assert system.as_dict()["config"] == system.config.as_dict(system.status.zones)
     assert system.as_dict()["energy"] == system.energy.as_dict()
-    assert system.as_dict()["config"]["zones"][0]["current_status_activity"]["type"] == "wake"
+    assert (
+        system.as_dict()["config"]["zones"][0]["current_activity"]["from_status"]["type"] == "wake"
+    )
     assert repr(system) == str(system.as_dict())
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -218,6 +218,29 @@ def test_config_zone_current_activity_from_status_returns_none_for_missing_profi
     assert config.zones[0].current_status_activity(status.zones[0]) is None
 
 
+def test_config_zone_current_activity_from_status_returns_none_for_wrong_zone(
+    system_response: dict[str, Any],
+) -> None:
+    """Return no profile when the supplied status belongs to another zone.
+
+    Args:
+        system_response: Parsed systems fixture.
+    """
+    raw_system = system_response["infinitySystems"][0]
+    config = Config(raw_system["config"])
+    wrong_status_zone = StatusZone(
+        {
+            **raw_system["status"]["zones"][0],
+            "id": "2",
+            "enabled": "on",
+            "currentActivity": "wake",
+        }
+    )
+
+    assert config.zones[0].current_status_activity(wrong_status_zone) is None
+    assert config.zones[0].as_dict(wrong_status_zone)["current_activity"]["from_status"] is None
+
+
 def test_config_next_activity_time_returns_none_when_today_and_tomorrow_are_disabled() -> None:
     """Return no next activity time when today and tomorrow have no enabled periods."""
     zone = ConfigZone(
@@ -340,6 +363,23 @@ def test_system_hvac_capabilities_ignore_ambiguous_profile_strings(
         "cool": False,
         "fan": False,
     }
+
+
+def test_system_hvac_capabilities_do_not_let_energy_override_config_fan_off(
+    systems: list[System],
+) -> None:
+    """Treat config fan control as authoritative over fan energy telemetry.
+
+    Args:
+        systems: Prepared system fixture models.
+    """
+    system = systems[0]
+    system.config.fan_enabled = False
+    system.energy.fan = True
+    system.energy.fan_gas = True
+
+    assert not system.supports_fan()
+    assert not system.supported_hvac_capabilities()["fan"]
 
 
 def test_safely_get_json_value_handles_nested_lists_none_and_cast_failures() -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -88,6 +88,8 @@ def test_status_modes_zone_conditioning_and_serialization(
     assert status.zones[0].current_activity == ActivityTypes.WAKE
     assert status.zones[0].as_dict()["current_activity"] == "wake"
     assert status.zones[0].as_dict()["current_status_activity"] == "wake"
+    status.zones[0].current_activity = ActivityTypes.HOME
+    assert status.zones[0].current_status_activity == ActivityTypes.HOME
     assert status.as_dict()["time_stamp"] == datetime(2025, 3, 3, 13, 42, 34, 328000, UTC)
     assert status.as_dict()["uv_lamp_level"] == 100
     assert repr(status.zones[0]) == str(status.zones[0].as_dict())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -308,6 +308,40 @@ def test_system_reports_supported_hvac_capabilities_from_equipment_and_config(
     }
 
 
+def test_system_hvac_capabilities_ignore_ambiguous_profile_strings(
+    system_response: dict[str, Any],
+    energy_response: dict[str, Any],
+) -> None:
+    """Avoid reporting support from incidental profile substrings.
+
+    Args:
+        system_response: Parsed systems fixture.
+        energy_response: Parsed energy fixture.
+    """
+    raw_system = deepcopy(system_response["infinitySystems"][0])
+    raw_system["profile"]["idutype"] = "package"
+    raw_system["profile"]["idusource"] = "none"
+    raw_system["profile"]["odutype"] = "package"
+    raw_system["config"]["cfgfan"] = "off"
+    raw_energy = deepcopy(energy_response["infinityEnergy"])
+    for energy_config in raw_energy["energyConfig"].values():
+        if isinstance(energy_config, dict):
+            energy_config["display"] = False
+            energy_config["enabled"] = False
+    system = System(
+        Profile(raw_system["profile"]),
+        Status(raw_system["status"]),
+        Config(raw_system["config"]),
+        Energy(raw_energy),
+    )
+
+    assert system.supported_hvac_capabilities() == {
+        "heat": False,
+        "cool": False,
+        "fan": False,
+    }
+
+
 def test_safely_get_json_value_handles_nested_lists_none_and_cast_failures() -> None:
     """Resolve nested JSON paths and return None for unsupported paths or casts."""
     payload = {"items": [{"value": "42"}, {"value": "none"}, {"value": "bad"}]}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -84,12 +84,12 @@ def test_status_modes_zone_conditioning_and_serialization(
 
     assert heat_status.mode_const == SystemModes.HEAT
     assert status.zones[0].zone_conditioning_const == SystemModes.HEAT
-    assert status.zones[0].current_status_activity == ActivityTypes.WAKE
+    assert status.zones[0].current_status_activity_type == ActivityTypes.WAKE
     assert status.zones[0].current_activity == ActivityTypes.WAKE
-    assert status.zones[0].as_dict()["current_activity"] == "wake"
-    assert status.zones[0].as_dict()["current_status_activity"] == "wake"
+    assert status.zones[0].as_dict()["current_status_activity_type"] == "wake"
+    assert "current_activity" not in status.zones[0].as_dict()
     status.zones[0].current_activity = ActivityTypes.HOME
-    assert status.zones[0].current_status_activity == ActivityTypes.HOME
+    assert status.zones[0].current_status_activity_type == ActivityTypes.HOME
     assert status.as_dict()["time_stamp"] == datetime(2025, 3, 3, 13, 42, 34, 328000, UTC)
     assert status.as_dict()["uv_lamp_level"] == 100
     assert repr(status.zones[0]) == str(status.zones[0].as_dict())

--- a/tests/test_websocket_data_updater.py
+++ b/tests/test_websocket_data_updater.py
@@ -256,15 +256,15 @@ async def test_status_zone_activity_message_handler(
         carrier_system: Prepared system model that receives the update.
         websocket_message_str: Raw zone activity websocket message fixture.
     """
-    assert carrier_system.status.zones[0].current_activity == ActivityTypes.WAKE
+    assert carrier_system.status.zones[0].current_status_activity == ActivityTypes.WAKE
     assert carrier_system.status.zones[0].heat_set_point == 74
     assert carrier_system.status.zones[0].cool_set_point == 78
     await data_updater.message_handler(websocket_message_str)
-    assert carrier_system.status.zones[0].current_activity == ActivityTypes.HOME
+    assert carrier_system.status.zones[0].current_status_activity == ActivityTypes.HOME
     assert carrier_system.status.zones[0].heat_set_point == 77
     assert carrier_system.status.zones[0].cool_set_point == 79
     reprocessed_status = Status(raw=carrier_system.status.raw)
-    assert reprocessed_status.zones[0].current_activity == ActivityTypes.HOME
+    assert reprocessed_status.zones[0].current_status_activity == ActivityTypes.HOME
     assert reprocessed_status.zones[0].heat_set_point == 77
     assert reprocessed_status.zones[0].cool_set_point == 79
 
@@ -285,13 +285,13 @@ async def test_status_zone_activity_only_message_handler(
         carrier_system: Prepared system model that receives the update.
         websocket_message_str: Raw activity-only websocket message fixture.
     """
-    assert carrier_system.status.zones[0].current_activity == ActivityTypes.WAKE
+    assert carrier_system.status.zones[0].current_status_activity == ActivityTypes.WAKE
     assert carrier_system.status.zones[0].fan == FanModes.MED
     await data_updater.message_handler(websocket_message_str)
-    assert carrier_system.status.zones[0].current_activity == ActivityTypes.SLEEP
+    assert carrier_system.status.zones[0].current_status_activity == ActivityTypes.SLEEP
     assert carrier_system.status.zones[0].fan == FanModes.MED
     reprocessed_status = Status(raw=carrier_system.status.raw)
-    assert reprocessed_status.zones[0].current_activity == ActivityTypes.SLEEP
+    assert reprocessed_status.zones[0].current_status_activity == ActivityTypes.SLEEP
     assert carrier_system.status.zones[0].fan == FanModes.MED
 
 
@@ -309,11 +309,11 @@ async def test_status_zone_hold_message_handler(
         carrier_system: Prepared system model that receives the update.
         websocket_message_str: Raw zone hold websocket message fixture.
     """
-    assert carrier_system.status.zones[0].current_activity == ActivityTypes.WAKE
+    assert carrier_system.status.zones[0].current_status_activity == ActivityTypes.WAKE
     await data_updater.message_handler(websocket_message_str)
-    assert carrier_system.status.zones[0].current_activity == ActivityTypes.MANUAL
+    assert carrier_system.status.zones[0].current_status_activity == ActivityTypes.MANUAL
     reprocessed_status = Status(raw=carrier_system.status.raw)
-    assert reprocessed_status.zones[0].current_activity == ActivityTypes.MANUAL
+    assert reprocessed_status.zones[0].current_status_activity == ActivityTypes.MANUAL
 
 
 @pytest.mark.asyncio

--- a/tests/test_websocket_data_updater.py
+++ b/tests/test_websocket_data_updater.py
@@ -256,15 +256,15 @@ async def test_status_zone_activity_message_handler(
         carrier_system: Prepared system model that receives the update.
         websocket_message_str: Raw zone activity websocket message fixture.
     """
-    assert carrier_system.status.zones[0].current_status_activity == ActivityTypes.WAKE
+    assert carrier_system.status.zones[0].current_status_activity_type == ActivityTypes.WAKE
     assert carrier_system.status.zones[0].heat_set_point == 74
     assert carrier_system.status.zones[0].cool_set_point == 78
     await data_updater.message_handler(websocket_message_str)
-    assert carrier_system.status.zones[0].current_status_activity == ActivityTypes.HOME
+    assert carrier_system.status.zones[0].current_status_activity_type == ActivityTypes.HOME
     assert carrier_system.status.zones[0].heat_set_point == 77
     assert carrier_system.status.zones[0].cool_set_point == 79
     reprocessed_status = Status(raw=carrier_system.status.raw)
-    assert reprocessed_status.zones[0].current_status_activity == ActivityTypes.HOME
+    assert reprocessed_status.zones[0].current_status_activity_type == ActivityTypes.HOME
     assert reprocessed_status.zones[0].heat_set_point == 77
     assert reprocessed_status.zones[0].cool_set_point == 79
 
@@ -285,13 +285,13 @@ async def test_status_zone_activity_only_message_handler(
         carrier_system: Prepared system model that receives the update.
         websocket_message_str: Raw activity-only websocket message fixture.
     """
-    assert carrier_system.status.zones[0].current_status_activity == ActivityTypes.WAKE
+    assert carrier_system.status.zones[0].current_status_activity_type == ActivityTypes.WAKE
     assert carrier_system.status.zones[0].fan == FanModes.MED
     await data_updater.message_handler(websocket_message_str)
-    assert carrier_system.status.zones[0].current_status_activity == ActivityTypes.SLEEP
+    assert carrier_system.status.zones[0].current_status_activity_type == ActivityTypes.SLEEP
     assert carrier_system.status.zones[0].fan == FanModes.MED
     reprocessed_status = Status(raw=carrier_system.status.raw)
-    assert reprocessed_status.zones[0].current_status_activity == ActivityTypes.SLEEP
+    assert reprocessed_status.zones[0].current_status_activity_type == ActivityTypes.SLEEP
     assert carrier_system.status.zones[0].fan == FanModes.MED
 
 
@@ -309,11 +309,11 @@ async def test_status_zone_hold_message_handler(
         carrier_system: Prepared system model that receives the update.
         websocket_message_str: Raw zone hold websocket message fixture.
     """
-    assert carrier_system.status.zones[0].current_status_activity == ActivityTypes.WAKE
+    assert carrier_system.status.zones[0].current_status_activity_type == ActivityTypes.WAKE
     await data_updater.message_handler(websocket_message_str)
-    assert carrier_system.status.zones[0].current_status_activity == ActivityTypes.MANUAL
+    assert carrier_system.status.zones[0].current_status_activity_type == ActivityTypes.MANUAL
     reprocessed_status = Status(raw=carrier_system.status.raw)
-    assert reprocessed_status.zones[0].current_status_activity == ActivityTypes.MANUAL
+    assert reprocessed_status.zones[0].current_status_activity_type == ActivityTypes.MANUAL
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Adds Carrier API helpers for resolving zone current activity profiles and exposing best-effort HVAC support signals. This makes status-vs-schedule activity sources explicit while keeping deprecated compatibility aliases for existing consumers.

## What Changed
- Added `System.supported_hvac_capabilities()` plus `supports_heat()`, `supports_cool()`, and `supports_fan()`.
- Added `ConfigZone.current_scheduled_activity()` for schedule/config-derived activity resolution.
- Added `ConfigZone.current_status_activity(status_zone)` for resolving Carrier status activity types into full configured activity profiles.
- Renamed status-zone activity storage to `current_status_activity_type` and kept `current_activity` as a deprecated compatibility alias.
- Updated `as_dict()` output so system/config serialization includes `supported_hvac_capabilities` and per-zone `current_activity.from_schedule` / `current_activity.from_status`.
- Documented the distinction between status-derived and schedule-derived activity values, including deprecated aliases.
- Added tests for activity resolution, serialization, HVAC support signals, websocket activity updates, and schedule boundary behavior.

## Why
Carrier status reports only the current activity type, while the full activity profile details live in config. This change exposes explicit API helpers for resolving those values without requiring downstream integrations to duplicate the lookup logic, and it documents the limits of the available HVAC capability signals.

## Validation
- `./.venv/bin/pytest`
- `./.venv/bin/mypy`
- `./.venv/bin/prek run --all-files`
