### PR TITLE
Add Energy API helpers

### DIFF
--- a/src/carrier_api/__init__.py
+++ b/src/carrier_api/__init__.py
@@ -5,7 +5,7 @@ from .api_websocket import ApiWebsocket
 from .api_websocket_data_updater import WebsocketDataUpdater
 from .config import Config, ConfigZone, ConfigZoneActivity
 from .const import ActivityTypes, FanModes, SystemModes, TemperatureUnits
-from .energy import Energy, EnergyMeasurement, EnergyPeriod, EnergyUsageMetric
+from .energy import ENERGY_USAGE_METRICS, Energy, EnergyMeasurement, EnergyPeriod, EnergyUsageMetric
 from .errors import (
     AuthError,
     BaseError,
@@ -21,6 +21,7 @@ from .status import Status, StatusUnit, StatusZone
 from .system import System
 
 __all__ = [
+    "ENERGY_USAGE_METRICS",
     "ActivityTypes",
     "ApiConnectionGraphql",
     "ApiWebsocket",

--- a/src/carrier_api/__init__.py
+++ b/src/carrier_api/__init__.py
@@ -5,7 +5,7 @@ from .api_websocket import ApiWebsocket
 from .api_websocket_data_updater import WebsocketDataUpdater
 from .config import Config, ConfigZone, ConfigZoneActivity
 from .const import ActivityTypes, FanModes, SystemModes, TemperatureUnits
-from .energy import Energy
+from .energy import Energy, EnergyMeasurement, EnergyPeriod, EnergyUsageMetric
 from .errors import (
     AuthError,
     BaseError,
@@ -16,8 +16,6 @@ from .errors import (
     CarrierApiTokenRefreshError,
     CarrierApiWebsocketError,
 )
-from .energy import Energy, EnergyMeasurement, EnergyPeriod, EnergyUsageMetric
-from .errors import AuthError, BaseError
 from .profile import Profile
 from .status import Status, StatusUnit, StatusZone
 from .system import System

--- a/src/carrier_api/__init__.py
+++ b/src/carrier_api/__init__.py
@@ -16,8 +16,10 @@ from .errors import (
     CarrierApiTokenRefreshError,
     CarrierApiWebsocketError,
 )
+from .energy import Energy, EnergyMeasurement, EnergyPeriod, EnergyUsageMetric
+from .errors import AuthError, BaseError
 from .profile import Profile
-from .status import Status, StatusZone
+from .status import Status, StatusUnit, StatusZone
 from .system import System
 
 __all__ = [
@@ -36,9 +38,13 @@ __all__ = [
     "ConfigZone",
     "ConfigZoneActivity",
     "Energy",
+    "EnergyMeasurement",
+    "EnergyPeriod",
+    "EnergyUsageMetric",
     "FanModes",
     "Profile",
     "Status",
+    "StatusUnit",
     "StatusZone",
     "System",
     "SystemModes",

--- a/src/carrier_api/__init__.py
+++ b/src/carrier_api/__init__.py
@@ -5,7 +5,13 @@ from .api_websocket import ApiWebsocket
 from .api_websocket_data_updater import WebsocketDataUpdater
 from .config import Config, ConfigZone, ConfigZoneActivity
 from .const import ActivityTypes, FanModes, SystemModes, TemperatureUnits
-from .energy import ENERGY_USAGE_METRICS, Energy, EnergyMeasurement, EnergyPeriod, EnergyUsageMetric
+from .energy import (
+    ENERGY_USAGE_METRIC_LABELS,
+    Energy,
+    EnergyMeasurement,
+    EnergyPeriod,
+    EnergyUsageMetric,
+)
 from .errors import (
     AuthError,
     BaseError,
@@ -21,7 +27,7 @@ from .status import Status, StatusUnit, StatusZone
 from .system import System
 
 __all__ = [
-    "ENERGY_USAGE_METRICS",
+    "ENERGY_USAGE_METRIC_LABELS",
     "ActivityTypes",
     "ApiConnectionGraphql",
     "ApiWebsocket",

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -31,7 +31,6 @@ from .system import System
 _LOGGER = getLogger(__name__)
 GRAPHQL_EXECUTE_TIMEOUT_SECONDS = 60
 
-_GRAPHQL_ERRORS = (GraphqlTransportError, TransportQueryError, GraphQLError)
 _CONNECTION_ERRORS = (GraphqlTransportError, ClientError, TimeoutError, OSError)
 _AUTH_HTTP_STATUSES = {401, 403}
 

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -363,6 +363,7 @@ class ApiConnectionGraphql:
                   odu {
                     type
                     opstat
+                    iducfm
                   }
                   filtrlvl
                   idu {

--- a/src/carrier_api/energy.py
+++ b/src/carrier_api/energy.py
@@ -215,6 +215,25 @@ class Energy:
         """
         return self.measurement_for_period(EnergyPeriod.YEAR_1)
 
+    def value_for_period_metric(
+        self, period_id: EnergyPeriod | str, metric: EnergyUsageMetric | str
+    ) -> int | None:
+        """Return an energy total for a reporting period and usage metric.
+
+        Args:
+            period_id: Carrier reporting period identifier such as ``year1``.
+            metric: Normalized metric enum or string such as ``gas`` or
+                ``hp_heat``.
+
+        Returns:
+            The integer energy total for the period and metric, or ``None``
+            when either the period or metric is not known.
+        """
+        measurement = self.measurement_for_period(period_id)
+        if measurement is None:
+            return None
+        return measurement.value_for_metric(metric)
+
     def is_usage_metric_enabled(self, metric: EnergyUsageMetric | str) -> bool:
         """Return whether an energy usage metric is enabled for this system.
 

--- a/src/carrier_api/energy.py
+++ b/src/carrier_api/energy.py
@@ -33,6 +33,19 @@ class EnergyUsageMetric(StrEnum):
     LOOP_PUMP = "loop_pump"
 
 
+ENERGY_USAGE_METRICS: tuple[EnergyUsageMetric, ...] = (
+    EnergyUsageMetric.COOLING,
+    EnergyUsageMetric.ELECTRIC_HEAT,
+    EnergyUsageMetric.FAN_GAS,
+    EnergyUsageMetric.FAN,
+    EnergyUsageMetric.GAS,
+    EnergyUsageMetric.HP_HEAT,
+    EnergyUsageMetric.LOOP_PUMP,
+    EnergyUsageMetric.REHEAT,
+)
+"""Canonical order for Carrier energy usage metrics."""
+
+
 class EnergyMeasurement:
     """Energy usage totals for a single Carrier reporting period."""
 
@@ -201,6 +214,32 @@ class Energy:
             ``None`` when the payload does not contain that period.
         """
         return self.measurement_for_period(EnergyPeriod.YEAR_1)
+
+    def is_usage_metric_enabled(self, metric: EnergyUsageMetric | str) -> bool:
+        """Return whether an energy usage metric is enabled for this system.
+
+        Args:
+            metric: Normalized metric enum or string such as ``gas`` or
+                ``cooling``.
+
+        Returns:
+            ``True`` when Carrier reports the metric as both displayable and
+            enabled, otherwise ``False``.
+        """
+        metric_name = metric.value if isinstance(metric, EnergyUsageMetric) else metric
+        if metric_name not in EnergyUsageMetric:
+            return False
+        return getattr(self, metric_name, False) is True
+
+    def enabled_usage_metrics(self) -> tuple[EnergyUsageMetric, ...]:
+        """Return energy usage metrics enabled for this system.
+
+        Returns:
+            Enabled metrics in the canonical Carrier API iteration order.
+        """
+        return tuple(
+            metric for metric in ENERGY_USAGE_METRICS if self.is_usage_metric_enabled(metric)
+        )
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of energy configuration and usage.

--- a/src/carrier_api/energy.py
+++ b/src/carrier_api/energy.py
@@ -1,12 +1,9 @@
 """Energy configuration and usage models for Carrier systems."""
 
 from enum import StrEnum
-from logging import getLogger
 from typing import Any
 
 from .util import safely_get_json_value
-
-_LOGGER = getLogger(__name__)
 
 
 class EnergyPeriod(StrEnum):
@@ -46,6 +43,21 @@ ENERGY_USAGE_METRICS: tuple[EnergyUsageMetric, ...] = (
 """Canonical order for Carrier energy usage metrics."""
 
 
+def _coerce_energy_usage_metric(metric: EnergyUsageMetric | str) -> EnergyUsageMetric | None:
+    """Return the normalized usage metric, if the input names one.
+
+    Args:
+        metric: Normalized metric enum or string.
+
+    Returns:
+        Matching usage metric, or ``None`` when the input is not supported.
+    """
+    try:
+        return EnergyUsageMetric(metric)
+    except ValueError:
+        return None
+
+
 class EnergyMeasurement:
     """Energy usage totals for a single Carrier reporting period."""
 
@@ -77,10 +89,10 @@ class EnergyMeasurement:
             The integer energy total for the metric, or ``None`` when the
             metric is not known.
         """
-        metric_name = metric.value if isinstance(metric, EnergyUsageMetric) else metric
-        if metric_name not in EnergyUsageMetric:
+        energy_metric = _coerce_energy_usage_metric(metric)
+        if energy_metric is None:
             return None
-        return getattr(self, metric_name)
+        return getattr(self, energy_metric.value)
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of the usage measurement.
@@ -142,7 +154,7 @@ class Energy:
             raw: Raw ``infinityEnergy`` object returned by the Carrier GraphQL API.
         """
         self.raw = raw
-        self.seer: int = safely_get_json_value(self.raw, "energyConfig.seer", float)
+        self.seer: float = safely_get_json_value(self.raw, "energyConfig.seer", float)
         self.hspf: float = safely_get_json_value(self.raw, "energyConfig.hspf", float)
         self.cooling: bool = safely_get_json_value(
             self.raw, "energyConfig.cooling.display", bool
@@ -245,10 +257,10 @@ class Energy:
             ``True`` when Carrier reports the metric as both displayable and
             enabled, otherwise ``False``.
         """
-        metric_name = metric.value if isinstance(metric, EnergyUsageMetric) else metric
-        if metric_name not in EnergyUsageMetric:
+        energy_metric = _coerce_energy_usage_metric(metric)
+        if energy_metric is None:
             return False
-        return getattr(self, metric_name, False) is True
+        return getattr(self, energy_metric.value, False) is True
 
     def enabled_usage_metrics(self) -> tuple[EnergyUsageMetric, ...]:
         """Return energy usage metrics enabled for this system.

--- a/src/carrier_api/energy.py
+++ b/src/carrier_api/energy.py
@@ -1,11 +1,36 @@
 """Energy configuration and usage models for Carrier systems."""
 
+from enum import StrEnum
 from logging import getLogger
 from typing import Any
 
 from .util import safely_get_json_value
 
 _LOGGER = getLogger(__name__)
+
+
+class EnergyPeriod(StrEnum):
+    """Carrier energy reporting period identifiers."""
+
+    DAY_1 = "day1"
+    DAY_2 = "day2"
+    MONTH_1 = "month1"
+    MONTH_2 = "month2"
+    YEAR_1 = "year1"
+    YEAR_2 = "year2"
+
+
+class EnergyUsageMetric(StrEnum):
+    """Normalized Carrier energy usage metric names."""
+
+    COOLING = "cooling"
+    HP_HEAT = "hp_heat"
+    FAN = "fan"
+    ELECTRIC_HEAT = "electric_heat"
+    REHEAT = "reheat"
+    FAN_GAS = "fan_gas"
+    GAS = "gas"
+    LOOP_PUMP = "loop_pump"
 
 
 class EnergyMeasurement:
@@ -27,6 +52,22 @@ class EnergyMeasurement:
         self.fan_gas: int = safely_get_json_value(energy_measurement_json, "fanGasKwh", int)
         self.gas: int = safely_get_json_value(energy_measurement_json, "gasKwh", int)
         self.loop_pump: int = safely_get_json_value(energy_measurement_json, "loopPumpKwh", int)
+
+    def value_for_metric(self, metric: EnergyUsageMetric | str) -> int | None:
+        """Return the energy total for a normalized metric name.
+
+        Args:
+            metric: Normalized metric enum or string such as ``gas`` or
+                ``hp_heat``.
+
+        Returns:
+            The integer energy total for the metric, or ``None`` when the
+            metric is not known.
+        """
+        metric_name = metric.value if isinstance(metric, EnergyUsageMetric) else metric
+        if metric_name not in EnergyUsageMetric:
+            return None
+        return getattr(self, metric_name)
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of the usage measurement.
@@ -118,6 +159,40 @@ class Energy:
         for period_json in self.raw["energyPeriods"]:
             self.periods.append(EnergyMeasurement(period_json))
 
+    def measurement_for_period(self, period_id: EnergyPeriod | str) -> EnergyMeasurement | None:
+        """Find energy totals for a Carrier reporting period.
+
+        Args:
+            period_id: Carrier reporting period identifier such as ``year1``.
+
+        Returns:
+            The measurement whose Carrier period identifier matches, or
+            ``None`` when the payload does not contain that period.
+        """
+        period_value = period_id.value if isinstance(period_id, EnergyPeriod) else period_id
+        for period in self.periods or []:
+            if period.api_id == period_value:
+                return period
+        return None
+
+    def current_day_measurements(self) -> EnergyMeasurement | None:
+        """Find the energy totals for the current-day reporting period.
+
+        Returns:
+            The measurement whose Carrier period identifier is ``day1``, or
+            ``None`` when the payload does not contain that period.
+        """
+        return self.measurement_for_period(EnergyPeriod.DAY_1)
+
+    def current_month_measurements(self) -> EnergyMeasurement | None:
+        """Find the energy totals for the current-month reporting period.
+
+        Returns:
+            The measurement whose Carrier period identifier is ``month1``, or
+            ``None`` when the payload does not contain that period.
+        """
+        return self.measurement_for_period(EnergyPeriod.MONTH_1)
+
     def current_year_measurements(self) -> EnergyMeasurement | None:
         """Find the energy totals for the current-year reporting period.
 
@@ -125,10 +200,7 @@ class Energy:
             The measurement whose Carrier period identifier is ``year1``, or
             ``None`` when the payload does not contain that period.
         """
-        for period in self.periods or []:
-            if period.api_id == "year1":
-                return period
-        return None
+        return self.measurement_for_period(EnergyPeriod.YEAR_1)
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of energy configuration and usage.

--- a/src/carrier_api/energy.py
+++ b/src/carrier_api/energy.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from .util import safely_get_json_value
 
+EnergyUsageValue = int | float | None
+
 
 class EnergyPeriod(StrEnum):
     """Carrier energy reporting period identifiers."""
@@ -99,18 +101,37 @@ def _energy_config_metric_enabled(raw: dict[str, Any], metric: EnergyUsageMetric
     )
 
 
+def _energy_usage_value(raw: dict[str, Any], key: str) -> EnergyUsageValue:
+    """Return an energy usage value while preserving whole numbers as ints.
+
+    Args:
+        raw: Raw energy period payload.
+        key: Carrier energy period usage key.
+
+    Returns:
+        Integer usage for whole-number payloads, fractional usage as a float,
+        or ``None`` when the payload value is absent or invalid.
+    """
+    value = safely_get_json_value(raw, key, float)
+    if value is None:
+        return None
+    if value.is_integer():
+        return int(value)
+    return value
+
+
 class EnergyMeasurement:
     """Energy usage totals for a single Carrier reporting period."""
 
     api_id: str | None = None
-    cooling: float | None = None
-    hp_heat: float | None = None
-    fan: float | None = None
-    electric_heat: float | None = None
-    reheat: float | None = None
-    fan_gas: float | None = None
-    gas: float | None = None
-    loop_pump: float | None = None
+    cooling: EnergyUsageValue = None
+    hp_heat: EnergyUsageValue = None
+    fan: EnergyUsageValue = None
+    electric_heat: EnergyUsageValue = None
+    reheat: EnergyUsageValue = None
+    fan_gas: EnergyUsageValue = None
+    gas: EnergyUsageValue = None
+    loop_pump: EnergyUsageValue = None
 
     def __init__(self, energy_measurement_json: dict[str, Any]) -> None:
         """Build an energy measurement from a Carrier energy period payload.
@@ -124,10 +145,10 @@ class EnergyMeasurement:
             setattr(
                 self,
                 metric.value,
-                safely_get_json_value(energy_measurement_json, spec.period_key, float),
+                _energy_usage_value(energy_measurement_json, spec.period_key),
             )
 
-    def value_for_metric(self, metric: EnergyUsageMetric | str) -> float | None:
+    def value_for_metric(self, metric: EnergyUsageMetric | str) -> EnergyUsageValue:
         """Return the energy total for a normalized metric name.
 
         Args:
@@ -248,7 +269,7 @@ class Energy:
 
     def value_for_period_metric(
         self, period_id: EnergyPeriod | str, metric: EnergyUsageMetric | str
-    ) -> float | None:
+    ) -> EnergyUsageValue:
         """Return an energy total for a reporting period and usage metric.
 
         Args:

--- a/src/carrier_api/energy.py
+++ b/src/carrier_api/energy.py
@@ -90,16 +90,18 @@ class EnergyMeasurement:
                 GraphQL API.
         """
         self.api_id = safely_get_json_value(energy_measurement_json, "energyPeriodType")
-        self.cooling: int = safely_get_json_value(energy_measurement_json, "coolingKwh", int)
-        self.hp_heat: int = safely_get_json_value(energy_measurement_json, "hPHeatKwh", int)
-        self.fan: int = safely_get_json_value(energy_measurement_json, "fanKwh", int)
-        self.electric_heat: int = safely_get_json_value(energy_measurement_json, "eHeatKwh", int)
-        self.reheat: int = safely_get_json_value(energy_measurement_json, "reheatKwh", int)
-        self.fan_gas: int = safely_get_json_value(energy_measurement_json, "fanGasKwh", int)
-        self.gas: int = safely_get_json_value(energy_measurement_json, "gasKwh", int)
-        self.loop_pump: int = safely_get_json_value(energy_measurement_json, "loopPumpKwh", int)
+        self.cooling: float = safely_get_json_value(energy_measurement_json, "coolingKwh", float)
+        self.hp_heat: float = safely_get_json_value(energy_measurement_json, "hPHeatKwh", float)
+        self.fan: float = safely_get_json_value(energy_measurement_json, "fanKwh", float)
+        self.electric_heat: float = safely_get_json_value(
+            energy_measurement_json, "eHeatKwh", float
+        )
+        self.reheat: float = safely_get_json_value(energy_measurement_json, "reheatKwh", float)
+        self.fan_gas: float = safely_get_json_value(energy_measurement_json, "fanGasKwh", float)
+        self.gas: float = safely_get_json_value(energy_measurement_json, "gasKwh", float)
+        self.loop_pump: float = safely_get_json_value(energy_measurement_json, "loopPumpKwh", float)
 
-    def value_for_metric(self, metric: EnergyUsageMetric | str) -> int | None:
+    def value_for_metric(self, metric: EnergyUsageMetric | str) -> float | None:
         """Return the energy total for a normalized metric name.
 
         Args:
@@ -107,13 +109,13 @@ class EnergyMeasurement:
                 ``hp_heat``.
 
         Returns:
-            The integer energy total for the metric, or ``None`` when the
+            The energy total for the metric, or ``None`` when the
             metric is not known.
         """
         energy_metric = _coerce_energy_usage_metric(metric)
         if energy_metric is None:
             return None
-        return getattr(self, energy_metric.value)
+        return getattr(self, energy_metric.value, None)
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of the usage measurement.
@@ -250,7 +252,7 @@ class Energy:
 
     def value_for_period_metric(
         self, period_id: EnergyPeriod | str, metric: EnergyUsageMetric | str
-    ) -> int | None:
+    ) -> float | None:
         """Return an energy total for a reporting period and usage metric.
 
         Args:
@@ -259,8 +261,8 @@ class Energy:
                 ``hp_heat``.
 
         Returns:
-            The integer energy total for the period and metric, or ``None``
-            when either the period or metric is not known.
+            The energy total for the period and metric, or ``None`` when either
+            the period or metric is not known.
         """
         measurement = self.measurement_for_period(period_id)
         if measurement is None:

--- a/src/carrier_api/energy.py
+++ b/src/carrier_api/energy.py
@@ -29,6 +29,15 @@ class EnergyUsageMetric(StrEnum):
     GAS = "gas"
     LOOP_PUMP = "loop_pump"
 
+    @property
+    def label(self) -> str:
+        """Return the human-readable label for the usage metric.
+
+        Returns:
+            Display label suitable for sensor names.
+        """
+        return _ENERGY_USAGE_METRIC_LABELS[self]
+
 
 ENERGY_USAGE_METRICS: tuple[EnergyUsageMetric, ...] = (
     EnergyUsageMetric.COOLING,
@@ -41,6 +50,18 @@ ENERGY_USAGE_METRICS: tuple[EnergyUsageMetric, ...] = (
     EnergyUsageMetric.REHEAT,
 )
 """Canonical order for Carrier energy usage metrics."""
+
+
+_ENERGY_USAGE_METRIC_LABELS: dict[EnergyUsageMetric, str] = {
+    EnergyUsageMetric.COOLING: "Cooling",
+    EnergyUsageMetric.ELECTRIC_HEAT: "Electric Heat",
+    EnergyUsageMetric.FAN_GAS: "Fan Gas",
+    EnergyUsageMetric.FAN: "Fan",
+    EnergyUsageMetric.GAS: "Gas",
+    EnergyUsageMetric.HP_HEAT: "Heat Pump Heat",
+    EnergyUsageMetric.LOOP_PUMP: "Loop Pump",
+    EnergyUsageMetric.REHEAT: "Reheat",
+}
 
 
 def _coerce_energy_usage_metric(metric: EnergyUsageMetric | str) -> EnergyUsageMetric | None:

--- a/src/carrier_api/energy.py
+++ b/src/carrier_api/energy.py
@@ -219,8 +219,8 @@ class Energy:
             raw: Raw ``infinityEnergy`` object returned by the Carrier GraphQL API.
         """
         self.raw = raw
-        self.seer: float = safely_get_json_value(self.raw, "energyConfig.seer", float)
-        self.hspf: float = safely_get_json_value(self.raw, "energyConfig.hspf", float)
+        self.seer = safely_get_json_value(self.raw, "energyConfig.seer", float)
+        self.hspf = safely_get_json_value(self.raw, "energyConfig.hspf", float)
         for metric in _ENERGY_METRICS:
             setattr(self, metric.value, _energy_config_metric_enabled(self.raw, metric))
         self.periods = []

--- a/src/carrier_api/energy.py
+++ b/src/carrier_api/energy.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from enum import StrEnum
+from math import isfinite
 from typing import Any
 
 from .util import safely_get_json_value
@@ -114,6 +115,8 @@ def _energy_usage_value(raw: dict[str, Any], key: str) -> EnergyUsageValue:
     """
     value = safely_get_json_value(raw, key, float)
     if value is None:
+        return None
+    if not isfinite(value):
         return None
     if value.is_integer():
         return int(value)

--- a/src/carrier_api/energy.py
+++ b/src/carrier_api/energy.py
@@ -1,5 +1,6 @@
 """Energy configuration and usage models for Carrier systems."""
 
+from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
@@ -36,31 +37,32 @@ class EnergyUsageMetric(StrEnum):
         Returns:
             Display label suitable for sensor names.
         """
-        return _ENERGY_USAGE_METRIC_LABELS[self]
+        return _ENERGY_METRICS[self].label
 
 
-ENERGY_USAGE_METRICS: tuple[EnergyUsageMetric, ...] = (
-    EnergyUsageMetric.COOLING,
-    EnergyUsageMetric.ELECTRIC_HEAT,
-    EnergyUsageMetric.FAN_GAS,
-    EnergyUsageMetric.FAN,
-    EnergyUsageMetric.GAS,
-    EnergyUsageMetric.HP_HEAT,
-    EnergyUsageMetric.LOOP_PUMP,
-    EnergyUsageMetric.REHEAT,
-)
-"""Canonical order for Carrier energy usage metrics."""
+@dataclass(frozen=True)
+class _EnergyMetricSpec:
+    """Carrier field mapping for a normalized energy usage metric."""
+
+    label: str
+    config_key: str
+    period_key: str
 
 
-_ENERGY_USAGE_METRIC_LABELS: dict[EnergyUsageMetric, str] = {
-    EnergyUsageMetric.COOLING: "Cooling",
-    EnergyUsageMetric.ELECTRIC_HEAT: "Electric Heat",
-    EnergyUsageMetric.FAN_GAS: "Fan Gas",
-    EnergyUsageMetric.FAN: "Fan",
-    EnergyUsageMetric.GAS: "Gas",
-    EnergyUsageMetric.HP_HEAT: "Heat Pump Heat",
-    EnergyUsageMetric.LOOP_PUMP: "Loop Pump",
-    EnergyUsageMetric.REHEAT: "Reheat",
+_ENERGY_METRICS: dict[EnergyUsageMetric, _EnergyMetricSpec] = {
+    EnergyUsageMetric.COOLING: _EnergyMetricSpec("Cooling", "cooling", "coolingKwh"),
+    EnergyUsageMetric.HP_HEAT: _EnergyMetricSpec("Heat Pump Heat", "hpheat", "hPHeatKwh"),
+    EnergyUsageMetric.FAN: _EnergyMetricSpec("Fan", "fan", "fanKwh"),
+    EnergyUsageMetric.ELECTRIC_HEAT: _EnergyMetricSpec("Electric Heat", "eheat", "eHeatKwh"),
+    EnergyUsageMetric.REHEAT: _EnergyMetricSpec("Reheat", "reheat", "reheatKwh"),
+    EnergyUsageMetric.FAN_GAS: _EnergyMetricSpec("Fan Gas", "fangas", "fanGasKwh"),
+    EnergyUsageMetric.GAS: _EnergyMetricSpec("Gas", "gas", "gasKwh"),
+    EnergyUsageMetric.LOOP_PUMP: _EnergyMetricSpec("Loop Pump", "looppump", "loopPumpKwh"),
+}
+
+# Human-readable labels for sensor-facing Carrier energy usage metrics.
+ENERGY_USAGE_METRIC_LABELS: dict[EnergyUsageMetric, str] = {
+    metric: spec.label for metric, spec in _ENERGY_METRICS.items()
 }
 
 
@@ -79,8 +81,36 @@ def _coerce_energy_usage_metric(metric: EnergyUsageMetric | str) -> EnergyUsageM
         return None
 
 
+def _energy_config_metric_enabled(raw: dict[str, Any], metric: EnergyUsageMetric) -> bool:
+    """Return whether Carrier marks a usage metric displayable and enabled.
+
+    Args:
+        raw: Raw ``infinityEnergy`` object returned by the Carrier GraphQL API.
+        metric: Normalized usage metric to inspect.
+
+    Returns:
+        ``True`` when the matching Carrier energy config entry is displayable
+        and enabled.
+    """
+    config_key = _ENERGY_METRICS[metric].config_key
+    return (
+        safely_get_json_value(raw, f"energyConfig.{config_key}.display", bool) is True
+        and safely_get_json_value(raw, f"energyConfig.{config_key}.enabled", bool) is True
+    )
+
+
 class EnergyMeasurement:
     """Energy usage totals for a single Carrier reporting period."""
+
+    api_id: str | None = None
+    cooling: float | None = None
+    hp_heat: float | None = None
+    fan: float | None = None
+    electric_heat: float | None = None
+    reheat: float | None = None
+    fan_gas: float | None = None
+    gas: float | None = None
+    loop_pump: float | None = None
 
     def __init__(self, energy_measurement_json: dict[str, Any]) -> None:
         """Build an energy measurement from a Carrier energy period payload.
@@ -90,16 +120,12 @@ class EnergyMeasurement:
                 GraphQL API.
         """
         self.api_id = safely_get_json_value(energy_measurement_json, "energyPeriodType")
-        self.cooling: float = safely_get_json_value(energy_measurement_json, "coolingKwh", float)
-        self.hp_heat: float = safely_get_json_value(energy_measurement_json, "hPHeatKwh", float)
-        self.fan: float = safely_get_json_value(energy_measurement_json, "fanKwh", float)
-        self.electric_heat: float = safely_get_json_value(
-            energy_measurement_json, "eHeatKwh", float
-        )
-        self.reheat: float = safely_get_json_value(energy_measurement_json, "reheatKwh", float)
-        self.fan_gas: float = safely_get_json_value(energy_measurement_json, "fanGasKwh", float)
-        self.gas: float = safely_get_json_value(energy_measurement_json, "gasKwh", float)
-        self.loop_pump: float = safely_get_json_value(energy_measurement_json, "loopPumpKwh", float)
+        for metric, spec in _ENERGY_METRICS.items():
+            setattr(
+                self,
+                metric.value,
+                safely_get_json_value(energy_measurement_json, spec.period_key, float),
+            )
 
     def value_for_metric(self, metric: EnergyUsageMetric | str) -> float | None:
         """Return the energy total for a normalized metric name.
@@ -123,16 +149,8 @@ class EnergyMeasurement:
         Returns:
             A dictionary containing kWh usage by energy category.
         """
-        return {
-            "id": self.api_id,
-            "cooling": self.cooling,
-            "hp_heat": self.hp_heat,
-            "fan": self.fan,
-            "electric_heat": self.electric_heat,
-            "reheat": self.reheat,
-            "fan_gas": self.fan_gas,
-            "gas": self.gas,
-            "loop_pump": self.loop_pump,
+        return {"id": self.api_id} | {
+            metric.value: self.value_for_metric(metric) for metric in _ENERGY_METRICS
         }
 
     def __repr__(self) -> str:
@@ -179,30 +197,8 @@ class Energy:
         self.raw = raw
         self.seer: float = safely_get_json_value(self.raw, "energyConfig.seer", float)
         self.hspf: float = safely_get_json_value(self.raw, "energyConfig.hspf", float)
-        self.cooling: bool = safely_get_json_value(
-            self.raw, "energyConfig.cooling.display", bool
-        ) and safely_get_json_value(self.raw, "energyConfig.cooling.enabled", bool)
-        self.hp_heat: bool = safely_get_json_value(
-            self.raw, "energyConfig.hpheat.display", bool
-        ) and safely_get_json_value(self.raw, "energyConfig.hpheat.enabled", bool)
-        self.fan: bool = safely_get_json_value(
-            self.raw, "energyConfig.fan.display", bool
-        ) and safely_get_json_value(self.raw, "energyConfig.fan.enabled", bool)
-        self.electric_heat: bool = safely_get_json_value(
-            self.raw, "energyConfig.eheat.display", bool
-        ) and safely_get_json_value(self.raw, "energyConfig.eheat.enabled", bool)
-        self.reheat: bool = safely_get_json_value(
-            self.raw, "energyConfig.reheat.display", bool
-        ) and safely_get_json_value(self.raw, "energyConfig.reheat.enabled", bool)
-        self.fan_gas: bool = safely_get_json_value(
-            self.raw, "energyConfig.fangas.display", bool
-        ) and safely_get_json_value(self.raw, "energyConfig.fangas.enabled", bool)
-        self.gas: bool = safely_get_json_value(
-            self.raw, "energyConfig.gas.display", bool
-        ) and safely_get_json_value(self.raw, "energyConfig.gas.enabled", bool)
-        self.loop_pump: bool = safely_get_json_value(
-            self.raw, "energyConfig.looppump.display", bool
-        ) and safely_get_json_value(self.raw, "energyConfig.looppump.enabled", bool)
+        for metric in _ENERGY_METRICS:
+            setattr(self, metric.value, _energy_config_metric_enabled(self.raw, metric))
         self.periods = []
         for period_json in self.raw["energyPeriods"]:
             self.periods.append(EnergyMeasurement(period_json))
@@ -291,9 +287,7 @@ class Energy:
         Returns:
             Enabled metrics in the canonical Carrier API iteration order.
         """
-        return tuple(
-            metric for metric in ENERGY_USAGE_METRICS if self.is_usage_metric_enabled(metric)
-        )
+        return tuple(metric for metric in _ENERGY_METRICS if self.is_usage_metric_enabled(metric))
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of energy configuration and usage.

--- a/src/carrier_api/status.py
+++ b/src/carrier_api/status.py
@@ -1,15 +1,12 @@
 """Current operational status models for Carrier systems and zones."""
 
 from datetime import datetime
-from logging import getLogger
 from typing import Any
 
 from dateutil.parser import isoparse
 
 from .const import ActivityTypes, FanModes, SystemModes, TemperatureUnits
 from .util import safely_get_json_value
-
-_LOGGER = getLogger(__name__)
 
 
 class StatusUnit:

--- a/src/carrier_api/status.py
+++ b/src/carrier_api/status.py
@@ -19,13 +19,15 @@ class StatusUnit:
             status_unit_json: Raw ``idu`` or ``odu`` object from the Carrier
                 status response.
         """
-        self.type: str = safely_get_json_value(status_unit_json, "type")
-        self.operational_status: str = safely_get_json_value(status_unit_json, "opstat")
+        self.type: str | None = safely_get_json_value(status_unit_json, "type")
+        self.operational_status: str | None = safely_get_json_value(status_unit_json, "opstat")
         self.airflow_cfm: int | None = safely_get_json_value(status_unit_json, "cfm", int)
         if self.airflow_cfm is None:
             self.airflow_cfm = safely_get_json_value(status_unit_json, "iducfm", int)
-        self.static_pressure: float = safely_get_json_value(status_unit_json, "statpress", float)
-        self.blower_rpm: int = safely_get_json_value(status_unit_json, "blwrpm", int)
+        self.static_pressure: float | None = safely_get_json_value(
+            status_unit_json, "statpress", float
+        )
+        self.blower_rpm: int | None = safely_get_json_value(status_unit_json, "blwrpm", int)
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation of unit runtime details.

--- a/src/carrier_api/status.py
+++ b/src/carrier_api/status.py
@@ -220,7 +220,9 @@ class Status:
             self.outdoor_unit = StatusUnit(self.raw["odu"])
         if self.raw.get("idu") is not None:
             self.indoor_unit = StatusUnit(self.raw["idu"])
-        self.airflow_cfm: int = safely_get_json_value(self.raw, "idu.cfm", int)
+        self.airflow_cfm: int | None = safely_get_json_value(self.raw, "idu.cfm", int)
+        if self.airflow_cfm is None and self.outdoor_unit is not None:
+            self.airflow_cfm = self.outdoor_unit.airflow_cfm
         self.blower_rpm: int = safely_get_json_value(self.raw, "idu.blwrpm", int)
         self.static_pressure: int = safely_get_json_value(self.raw, "idu.statpress", float)
         self.outdoor_unit_operational_status: str = safely_get_json_value(self.raw, "odu.opstat")

--- a/src/carrier_api/status.py
+++ b/src/carrier_api/status.py
@@ -12,6 +12,54 @@ from .util import safely_get_json_value
 _LOGGER = getLogger(__name__)
 
 
+class StatusUnit:
+    """Runtime status details for a Carrier indoor or outdoor unit."""
+
+    def __init__(self, status_unit_json: dict[str, Any]) -> None:
+        """Build unit status details from a Carrier unit status payload.
+
+        Args:
+            status_unit_json: Raw ``idu`` or ``odu`` object from the Carrier
+                status response.
+        """
+        self.type: str = safely_get_json_value(status_unit_json, "type")
+        self.operational_status: str = safely_get_json_value(status_unit_json, "opstat")
+        self.airflow_cfm: int = safely_get_json_value(status_unit_json, "cfm", int)
+        self.static_pressure: float = safely_get_json_value(status_unit_json, "statpress", float)
+        self.blower_rpm: int = safely_get_json_value(status_unit_json, "blwrpm", int)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dictionary representation of unit runtime details.
+
+        Returns:
+            A dictionary containing available unit status values.
+        """
+        values = {
+            "type": self.type,
+            "operational_status": self.operational_status,
+            "airflow_cfm": self.airflow_cfm,
+            "static_pressure": self.static_pressure,
+            "blower_rpm": self.blower_rpm,
+        }
+        return {key: value for key, value in values.items() if value is not None}
+
+    def __repr__(self) -> str:
+        """Return a developer-readable representation of the unit status.
+
+        Returns:
+            The unit status dictionary representation converted to a string.
+        """
+        return str(self.as_dict())
+
+    def __str__(self) -> str:
+        """Return a readable string representation of the unit status.
+
+        Returns:
+            The unit status representation converted to a string.
+        """
+        return str(self.as_dict())
+
+
 class StatusZone:
     """Runtime status reported by Carrier for a single zone."""
 
@@ -144,6 +192,8 @@ class Status:
     uv_lamp_level: int | None = None
     outdoor_unit_operational_status: str | None = None
     indoor_unit_operational_status: str | None = None
+    outdoor_unit: StatusUnit | None = None
+    indoor_unit: StatusUnit | None = None
     time_stamp: datetime | None = None
     zones: list[StatusZone]
 
@@ -166,6 +216,10 @@ class Status:
             self.humidifier_on: bool = safely_get_json_value(self.raw, "humid", str) == "on"
         self.uv_lamp_level: int = safely_get_json_value(self.raw, "uvlvl", int)
         self.is_disconnected: bool = safely_get_json_value(self.raw, "isDisconnected", bool)
+        if self.raw.get("odu") is not None:
+            self.outdoor_unit = StatusUnit(self.raw["odu"])
+        if self.raw.get("idu") is not None:
+            self.indoor_unit = StatusUnit(self.raw["idu"])
         self.airflow_cfm: int = safely_get_json_value(self.raw, "idu.cfm", int)
         self.blower_rpm: int = safely_get_json_value(self.raw, "idu.blwrpm", int)
         self.static_pressure: int = safely_get_json_value(self.raw, "idu.statpress", float)
@@ -217,6 +271,8 @@ class Status:
             "uv_lamp_level": self.uv_lamp_level,
             "outdoor_unit_operational_status": self.outdoor_unit_operational_status,
             "indoor_unit_operational_status": self.indoor_unit_operational_status,
+            "outdoor_unit": self.outdoor_unit.as_dict() if self.outdoor_unit is not None else None,
+            "indoor_unit": self.indoor_unit.as_dict() if self.indoor_unit is not None else None,
             "zones": [zone.as_dict() for zone in self.zones or []],
         }
 

--- a/src/carrier_api/status.py
+++ b/src/carrier_api/status.py
@@ -22,6 +22,8 @@ class StatusUnit:
         self.type: str = safely_get_json_value(status_unit_json, "type")
         self.operational_status: str = safely_get_json_value(status_unit_json, "opstat")
         self.airflow_cfm: int | None = safely_get_json_value(status_unit_json, "cfm", int)
+        if self.airflow_cfm is None:
+            self.airflow_cfm = safely_get_json_value(status_unit_json, "iducfm", int)
         self.static_pressure: float = safely_get_json_value(status_unit_json, "statpress", float)
         self.blower_rpm: int = safely_get_json_value(status_unit_json, "blwrpm", int)
 
@@ -218,8 +220,6 @@ class Status:
         if self.raw.get("idu") is not None:
             self.indoor_unit = StatusUnit(self.raw["idu"])
         self.airflow_cfm: int | None = safely_get_json_value(self.raw, "idu.cfm", int)
-        if self.airflow_cfm is None:
-            self.airflow_cfm = safely_get_json_value(self.raw, "odu.iducfm", int)
         if self.airflow_cfm is None and self.outdoor_unit is not None:
             self.airflow_cfm = self.outdoor_unit.airflow_cfm
         self.blower_rpm: int = safely_get_json_value(self.raw, "idu.blwrpm", int)

--- a/src/carrier_api/status.py
+++ b/src/carrier_api/status.py
@@ -21,10 +21,7 @@ class StatusUnit:
         """
         self.type: str = safely_get_json_value(status_unit_json, "type")
         self.operational_status: str = safely_get_json_value(status_unit_json, "opstat")
-        airflow_cfm: int | None = safely_get_json_value(status_unit_json, "cfm", int)
-        if airflow_cfm is None:
-            airflow_cfm = safely_get_json_value(status_unit_json, "iducfm", int)
-        self.airflow_cfm = airflow_cfm
+        self.airflow_cfm: int | None = safely_get_json_value(status_unit_json, "cfm", int)
         self.static_pressure: float = safely_get_json_value(status_unit_json, "statpress", float)
         self.blower_rpm: int = safely_get_json_value(status_unit_json, "blwrpm", int)
 
@@ -221,6 +218,8 @@ class Status:
         if self.raw.get("idu") is not None:
             self.indoor_unit = StatusUnit(self.raw["idu"])
         self.airflow_cfm: int | None = safely_get_json_value(self.raw, "idu.cfm", int)
+        if self.airflow_cfm is None:
+            self.airflow_cfm = safely_get_json_value(self.raw, "odu.iducfm", int)
         if self.airflow_cfm is None and self.outdoor_unit is not None:
             self.airflow_cfm = self.outdoor_unit.airflow_cfm
         self.blower_rpm: int = safely_get_json_value(self.raw, "idu.blwrpm", int)

--- a/src/carrier_api/status.py
+++ b/src/carrier_api/status.py
@@ -22,8 +22,6 @@ class StatusUnit:
         self.type: str | None = safely_get_json_value(status_unit_json, "type")
         self.operational_status: str | None = safely_get_json_value(status_unit_json, "opstat")
         self.airflow_cfm: int | None = safely_get_json_value(status_unit_json, "cfm", int)
-        if self.airflow_cfm is None:
-            self.airflow_cfm = safely_get_json_value(status_unit_json, "iducfm", int)
         self.static_pressure: float | None = safely_get_json_value(
             status_unit_json, "statpress", float
         )
@@ -222,8 +220,10 @@ class Status:
         if self.raw.get("idu") is not None:
             self.indoor_unit = StatusUnit(self.raw["idu"])
         self.airflow_cfm: int | None = safely_get_json_value(self.raw, "idu.cfm", int)
-        if self.airflow_cfm is None and self.outdoor_unit is not None:
-            self.airflow_cfm = self.outdoor_unit.airflow_cfm
+        if self.airflow_cfm is None:
+            self.airflow_cfm = safely_get_json_value(self.raw, "odu.iducfm", int)
+        if self.indoor_unit is not None and self.indoor_unit.airflow_cfm is None:
+            self.indoor_unit.airflow_cfm = self.airflow_cfm
         self.blower_rpm: int = safely_get_json_value(self.raw, "idu.blwrpm", int)
         self.static_pressure: int = safely_get_json_value(self.raw, "idu.statpress", float)
         self.outdoor_unit_operational_status: str = safely_get_json_value(self.raw, "odu.opstat")

--- a/src/carrier_api/status.py
+++ b/src/carrier_api/status.py
@@ -21,7 +21,10 @@ class StatusUnit:
         """
         self.type: str = safely_get_json_value(status_unit_json, "type")
         self.operational_status: str = safely_get_json_value(status_unit_json, "opstat")
-        self.airflow_cfm: int = safely_get_json_value(status_unit_json, "cfm", int)
+        airflow_cfm: int | None = safely_get_json_value(status_unit_json, "cfm", int)
+        if airflow_cfm is None:
+            airflow_cfm = safely_get_json_value(status_unit_json, "iducfm", int)
+        self.airflow_cfm = airflow_cfm
         self.static_pressure: float = safely_get_json_value(status_unit_json, "statpress", float)
         self.blower_rpm: int = safely_get_json_value(status_unit_json, "blwrpm", int)
 

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -10,7 +10,7 @@ import pytest
 
 import carrier_api
 from carrier_api import errors
-from carrier_api.api_connection_graphql import _GRAPHQL_ERRORS, ApiConnectionGraphql
+from carrier_api.api_connection_graphql import ApiConnectionGraphql
 from carrier_api.const import ActivityTypes, FanModes, HeatSourceTypes, SystemModes
 from carrier_api.system import System
 
@@ -344,11 +344,6 @@ def test_public_error_exports_use_carrier_api_prefix() -> None:
     assert errors.BaseError is errors.CarrierApiError
     assert carrier_api.AuthError is errors.CarrierApiAuthError
     assert carrier_api.BaseError is errors.CarrierApiError
-
-
-def test_graphql_error_tuple_catches_transport_query_errors() -> None:
-    """Include query errors explicitly in the wrapped GraphQL error set."""
-    assert TransportQueryError in _GRAPHQL_ERRORS
 
 
 @pytest.mark.asyncio

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -101,6 +101,11 @@ def test_energy_period_helpers_return_sensor_measurements(
     assert daily.value_for_metric(EnergyUsageMetric.GAS) == 397
     assert monthly.value_for_metric(EnergyUsageMetric.GAS) == 11012
     assert yearly.value_for_metric(EnergyUsageMetric.GAS) == 25905
+    assert energy.value_for_period_metric(EnergyPeriod.DAY_1, EnergyUsageMetric.GAS) == 397
+    assert energy.value_for_period_metric(EnergyPeriod.MONTH_1, "gas") == 11012
+    assert energy.value_for_period_metric(EnergyPeriod.YEAR_1, "hp_heat") == 0
+    assert energy.value_for_period_metric("missing", EnergyUsageMetric.GAS) is None
+    assert energy.value_for_period_metric(EnergyPeriod.YEAR_1, "unknown") is None
     assert yearly.value_for_metric("hp_heat") == 0
     assert yearly.value_for_metric("unknown") is None
     assert energy.measurement_for_period("missing") is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,16 @@ from typing import Any
 
 import pytest
 
-from carrier_api import Config, Energy, EnergyPeriod, EnergyUsageMetric, Profile, Status, System
+from carrier_api import (
+    ENERGY_USAGE_METRICS,
+    Config,
+    Energy,
+    EnergyPeriod,
+    EnergyUsageMetric,
+    Profile,
+    Status,
+    System,
+)
 from carrier_api.config import ConfigZone, ConfigZoneActivity, active_schedule_periods
 from carrier_api.const import ActivityTypes, FanModes, SystemModes
 from carrier_api.status import StatusZone
@@ -93,6 +102,36 @@ def test_energy_period_helpers_return_sensor_measurements(
     assert yearly.value_for_metric("hp_heat") == 0
     assert yearly.value_for_metric("unknown") is None
     assert energy.measurement_for_period("missing") is None
+
+
+def test_energy_enabled_usage_metrics_use_api_metric_vocabulary(
+    energy_response: dict[str, Any],
+) -> None:
+    """Expose enabled usage metrics without caller-owned raw field maps.
+
+    Args:
+        energy_response: Parsed energy fixture.
+    """
+    energy = Energy(energy_response["infinityEnergy"])
+
+    assert ENERGY_USAGE_METRICS == (
+        EnergyUsageMetric.COOLING,
+        EnergyUsageMetric.ELECTRIC_HEAT,
+        EnergyUsageMetric.FAN_GAS,
+        EnergyUsageMetric.FAN,
+        EnergyUsageMetric.GAS,
+        EnergyUsageMetric.HP_HEAT,
+        EnergyUsageMetric.LOOP_PUMP,
+        EnergyUsageMetric.REHEAT,
+    )
+    assert energy.enabled_usage_metrics() == (
+        EnergyUsageMetric.COOLING,
+        EnergyUsageMetric.GAS,
+    )
+    assert energy.is_usage_metric_enabled(EnergyUsageMetric.COOLING) is True
+    assert energy.is_usage_metric_enabled("gas") is True
+    assert energy.is_usage_metric_enabled(EnergyUsageMetric.ELECTRIC_HEAT) is False
+    assert energy.is_usage_metric_enabled("unknown") is False
 
 
 def test_status_modes_zone_conditioning_and_serialization(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -136,6 +136,29 @@ def test_energy_measurements_preserve_fractional_usage_values(
     assert current_day.as_dict()["cooling"] == 0.9
 
 
+@pytest.mark.parametrize("invalid_value", ["nan", "inf", "1e999"])
+def test_energy_measurements_reject_non_finite_usage_values(
+    energy_response: dict[str, Any],
+    invalid_value: str,
+) -> None:
+    """Reject non-finite energy readings instead of leaking invalid floats.
+
+    Args:
+        energy_response: Parsed energy fixture.
+        invalid_value: Invalid energy value to parse.
+    """
+    energy_payload = deepcopy(energy_response["infinityEnergy"])
+    energy_payload["energyPeriods"][0]["gasKwh"] = invalid_value
+
+    energy = Energy(energy_payload)
+    current_day = energy.current_day_measurements()
+
+    assert current_day is not None
+    assert current_day.gas is None
+    assert current_day.value_for_metric(EnergyUsageMetric.GAS) is None
+    assert current_day.as_dict()["gas"] is None
+
+
 def test_energy_measurement_missing_metric_attribute_returns_none(
     energy_response: dict[str, Any],
 ) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from carrier_api import (
-    ENERGY_USAGE_METRICS,
+    ENERGY_USAGE_METRIC_LABELS,
     Config,
     Energy,
     EnergyPeriod,
@@ -104,7 +104,7 @@ def test_energy_period_helpers_return_sensor_measurements(
     assert energy.value_for_period_metric(EnergyPeriod.DAY_1, EnergyUsageMetric.GAS) == 397
     assert energy.value_for_period_metric(EnergyPeriod.MONTH_1, "gas") == 11012
     assert energy.value_for_period_metric(EnergyPeriod.YEAR_1, "hp_heat") == 0
-    assert energy.value_for_period_metric("missing", EnergyUsageMetric.GAS) is None
+    assert energy.value_for_period_metric("missing", "gas") is None
     assert energy.value_for_period_metric(EnergyPeriod.YEAR_1, "unknown") is None
     assert yearly.value_for_metric("hp_heat") == 0
     assert yearly.value_for_metric("unknown") is None
@@ -160,16 +160,6 @@ def test_energy_enabled_usage_metrics_use_api_metric_vocabulary(
     """
     energy = Energy(energy_response["infinityEnergy"])
 
-    assert ENERGY_USAGE_METRICS == (
-        EnergyUsageMetric.COOLING,
-        EnergyUsageMetric.ELECTRIC_HEAT,
-        EnergyUsageMetric.FAN_GAS,
-        EnergyUsageMetric.FAN,
-        EnergyUsageMetric.GAS,
-        EnergyUsageMetric.HP_HEAT,
-        EnergyUsageMetric.LOOP_PUMP,
-        EnergyUsageMetric.REHEAT,
-    )
     assert energy.enabled_usage_metrics() == (
         EnergyUsageMetric.COOLING,
         EnergyUsageMetric.GAS,
@@ -182,15 +172,25 @@ def test_energy_enabled_usage_metrics_use_api_metric_vocabulary(
 
 def test_energy_usage_metrics_expose_display_labels() -> None:
     """Expose human-readable labels for sensor names."""
-    assert {metric.value: metric.label for metric in ENERGY_USAGE_METRICS} == {
+    assert ENERGY_USAGE_METRIC_LABELS == {
+        EnergyUsageMetric.COOLING: "Cooling",
+        EnergyUsageMetric.ELECTRIC_HEAT: "Electric Heat",
+        EnergyUsageMetric.FAN_GAS: "Fan Gas",
+        EnergyUsageMetric.FAN: "Fan",
+        EnergyUsageMetric.GAS: "Gas",
+        EnergyUsageMetric.HP_HEAT: "Heat Pump Heat",
+        EnergyUsageMetric.LOOP_PUMP: "Loop Pump",
+        EnergyUsageMetric.REHEAT: "Reheat",
+    }
+    assert {metric.value: metric.label for metric in EnergyUsageMetric} == {
         "cooling": "Cooling",
-        "electric_heat": "Electric Heat",
-        "fan_gas": "Fan Gas",
-        "fan": "Fan",
-        "gas": "Gas",
         "hp_heat": "Heat Pump Heat",
-        "loop_pump": "Loop Pump",
+        "fan": "Fan",
+        "electric_heat": "Electric Heat",
         "reheat": "Reheat",
+        "fan_gas": "Fan Gas",
+        "gas": "Gas",
+        "loop_pump": "Loop Pump",
     }
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -257,8 +257,8 @@ def test_status_modes_zone_conditioning_and_serialization(
         }
     )
     assert odu_with_airflow.outdoor_unit is not None
-    assert odu_with_airflow.outdoor_unit.airflow_cfm is None
-    assert "airflow_cfm" not in odu_with_airflow.outdoor_unit.as_dict()
+    assert odu_with_airflow.outdoor_unit.airflow_cfm == 482
+    assert odu_with_airflow.outdoor_unit.as_dict()["airflow_cfm"] == 482
     assert odu_with_airflow.airflow_cfm == 482
     assert odu_with_airflow.as_dict()["airflow_cfm"] == 482
     assert status.indoor_unit is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -257,8 +257,11 @@ def test_status_modes_zone_conditioning_and_serialization(
         }
     )
     assert odu_with_airflow.outdoor_unit is not None
-    assert odu_with_airflow.outdoor_unit.airflow_cfm == 482
-    assert odu_with_airflow.outdoor_unit.as_dict()["airflow_cfm"] == 482
+    assert odu_with_airflow.outdoor_unit.airflow_cfm is None
+    assert "airflow_cfm" not in odu_with_airflow.outdoor_unit.as_dict()
+    assert odu_with_airflow.indoor_unit is not None
+    assert odu_with_airflow.indoor_unit.airflow_cfm == 482
+    assert odu_with_airflow.indoor_unit.as_dict()["airflow_cfm"] == 482
     assert odu_with_airflow.airflow_cfm == 482
     assert odu_with_airflow.as_dict()["airflow_cfm"] == 482
     assert status.indoor_unit is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -222,10 +222,19 @@ def test_status_modes_zone_conditioning_and_serialization(
         "type": "ac2stgeverest",
         "operational_status": "off",
     }
-    odu_with_airflow = Status({**raw_status, "odu": {**raw_status["odu"], "iducfm": "482"}})
+    idu_without_airflow = {key: value for key, value in raw_status["idu"].items() if key != "cfm"}
+    odu_with_airflow = Status(
+        {
+            **raw_status,
+            "idu": idu_without_airflow,
+            "odu": {**raw_status["odu"], "iducfm": "482"},
+        }
+    )
     assert odu_with_airflow.outdoor_unit is not None
     assert odu_with_airflow.outdoor_unit.airflow_cfm == 482
     assert odu_with_airflow.outdoor_unit.as_dict()["airflow_cfm"] == 482
+    assert odu_with_airflow.airflow_cfm == 482
+    assert odu_with_airflow.as_dict()["airflow_cfm"] == 482
     assert status.indoor_unit is not None
     indoor_unit_data = status.indoor_unit.as_dict()
     assert indoor_unit_data == {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -89,11 +89,13 @@ def test_energy_period_helpers_return_sensor_measurements(
     energy = Energy(energy_response["infinityEnergy"])
 
     daily = energy.measurement_for_period(EnergyPeriod.DAY_1)
+    current_day = energy.current_day_measurements()
     monthly = energy.current_month_measurements()
     yearly = energy.current_year_measurements()
 
-    assert daily is energy.current_day_measurements()
     assert daily is not None
+    assert current_day is not None
+    assert daily.as_dict() == current_day.as_dict()
     assert monthly is not None
     assert yearly is not None
     assert daily.value_for_metric(EnergyUsageMetric.GAS) == 397
@@ -163,11 +165,12 @@ def test_status_modes_zone_conditioning_and_serialization(
         "operational_status": "off",
     }
     assert status.indoor_unit is not None
-    assert status.indoor_unit.as_dict() == {
+    indoor_unit_data = status.indoor_unit.as_dict()
+    assert indoor_unit_data == {
         "type": "furnace2stg",
         "operational_status": "low",
         "airflow_cfm": 1239,
-        "static_pressure": 1.399999976158142,
+        "static_pressure": pytest.approx(1.399999976158142),
         "blower_rpm": 1224,
     }
     assert repr(status.zones[0]) == str(status.zones[0].as_dict())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from carrier_api import Config, Energy, Profile, Status, System
+from carrier_api import Config, Energy, EnergyPeriod, EnergyUsageMetric, Profile, Status, System
 from carrier_api.config import ConfigZone, ConfigZoneActivity, active_schedule_periods
 from carrier_api.const import ActivityTypes, FanModes, SystemModes
 from carrier_api.status import StatusZone
@@ -69,6 +69,32 @@ def test_energy_as_dict_current_year_and_missing_year(
     assert str(current_year) == str(current_year.as_dict())
 
 
+def test_energy_period_helpers_return_sensor_measurements(
+    energy_response: dict[str, Any],
+) -> None:
+    """Look up sensor-facing energy values without raw payload access.
+
+    Args:
+        energy_response: Parsed energy fixture.
+    """
+    energy = Energy(energy_response["infinityEnergy"])
+
+    daily = energy.measurement_for_period(EnergyPeriod.DAY_1)
+    monthly = energy.current_month_measurements()
+    yearly = energy.current_year_measurements()
+
+    assert daily is energy.current_day_measurements()
+    assert daily is not None
+    assert monthly is not None
+    assert yearly is not None
+    assert daily.value_for_metric(EnergyUsageMetric.GAS) == 397
+    assert monthly.value_for_metric(EnergyUsageMetric.GAS) == 11012
+    assert yearly.value_for_metric(EnergyUsageMetric.GAS) == 25905
+    assert yearly.value_for_metric("hp_heat") == 0
+    assert yearly.value_for_metric("unknown") is None
+    assert energy.measurement_for_period("missing") is None
+
+
 def test_status_modes_zone_conditioning_and_serialization(
     system_response: dict[str, Any],
 ) -> None:
@@ -92,6 +118,19 @@ def test_status_modes_zone_conditioning_and_serialization(
     assert status.zones[0].current_status_activity_type == ActivityTypes.HOME
     assert status.as_dict()["time_stamp"] == datetime(2025, 3, 3, 13, 42, 34, 328000, UTC)
     assert status.as_dict()["uv_lamp_level"] == 100
+    assert status.outdoor_unit is not None
+    assert status.outdoor_unit.as_dict() == {
+        "type": "ac2stgeverest",
+        "operational_status": "off",
+    }
+    assert status.indoor_unit is not None
+    assert status.indoor_unit.as_dict() == {
+        "type": "furnace2stg",
+        "operational_status": "low",
+        "airflow_cfm": 1239,
+        "static_pressure": 1.399999976158142,
+        "blower_rpm": 1224,
+    }
     assert repr(status.zones[0]) == str(status.zones[0].as_dict())
 
     cool_zone = StatusZone({**raw_status["zones"][0], "zoneconditioning": "active_cool"})

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,6 +99,8 @@ def test_energy_period_helpers_return_sensor_measurements(
     assert monthly is not None
     assert yearly is not None
     assert daily.value_for_metric(EnergyUsageMetric.GAS) == 397
+    assert isinstance(daily.value_for_metric(EnergyUsageMetric.GAS), int)
+    assert isinstance(daily.as_dict()["gas"], int)
     assert monthly.value_for_metric(EnergyUsageMetric.GAS) == 11012
     assert yearly.value_for_metric(EnergyUsageMetric.GAS) == 25905
     assert energy.value_for_period_metric(EnergyPeriod.DAY_1, EnergyUsageMetric.GAS) == 397
@@ -128,6 +130,7 @@ def test_energy_measurements_preserve_fractional_usage_values(
 
     assert current_day is not None
     assert current_day.cooling == 0.9
+    assert isinstance(current_day.cooling, float)
     assert current_day.value_for_metric(EnergyUsageMetric.COOLING) == 0.9
     assert energy.value_for_period_metric(EnergyPeriod.DAY_1, EnergyUsageMetric.GAS) == 397.5
     assert current_day.as_dict()["cooling"] == 0.9
@@ -231,8 +234,8 @@ def test_status_modes_zone_conditioning_and_serialization(
         }
     )
     assert odu_with_airflow.outdoor_unit is not None
-    assert odu_with_airflow.outdoor_unit.airflow_cfm == 482
-    assert odu_with_airflow.outdoor_unit.as_dict()["airflow_cfm"] == 482
+    assert odu_with_airflow.outdoor_unit.airflow_cfm is None
+    assert "airflow_cfm" not in odu_with_airflow.outdoor_unit.as_dict()
     assert odu_with_airflow.airflow_cfm == 482
     assert odu_with_airflow.as_dict()["airflow_cfm"] == 482
     assert status.indoor_unit is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -111,6 +111,45 @@ def test_energy_period_helpers_return_sensor_measurements(
     assert energy.measurement_for_period("missing") is None
 
 
+def test_energy_measurements_preserve_fractional_usage_values(
+    energy_response: dict[str, Any],
+) -> None:
+    """Preserve fractional Carrier energy readings for sensor consumers.
+
+    Args:
+        energy_response: Parsed energy fixture.
+    """
+    energy_payload = deepcopy(energy_response["infinityEnergy"])
+    energy_payload["energyPeriods"][0]["coolingKwh"] = 0.9
+    energy_payload["energyPeriods"][0]["gasKwh"] = 397.5
+
+    energy = Energy(energy_payload)
+    current_day = energy.current_day_measurements()
+
+    assert current_day is not None
+    assert current_day.cooling == 0.9
+    assert current_day.value_for_metric(EnergyUsageMetric.COOLING) == 0.9
+    assert energy.value_for_period_metric(EnergyPeriod.DAY_1, EnergyUsageMetric.GAS) == 397.5
+    assert current_day.as_dict()["cooling"] == 0.9
+
+
+def test_energy_measurement_missing_metric_attribute_returns_none(
+    energy_response: dict[str, Any],
+) -> None:
+    """Return None when a normalized metric attribute is unavailable.
+
+    Args:
+        energy_response: Parsed energy fixture.
+    """
+    energy = Energy(energy_response["infinityEnergy"])
+    current_day = energy.current_day_measurements()
+
+    assert current_day is not None
+    del current_day.gas
+
+    assert current_day.value_for_metric(EnergyUsageMetric.GAS) is None
+
+
 def test_energy_enabled_usage_metrics_use_api_metric_vocabulary(
     energy_response: dict[str, Any],
 ) -> None:
@@ -183,6 +222,10 @@ def test_status_modes_zone_conditioning_and_serialization(
         "type": "ac2stgeverest",
         "operational_status": "off",
     }
+    odu_with_airflow = Status({**raw_status, "odu": {**raw_status["odu"], "iducfm": "482"}})
+    assert odu_with_airflow.outdoor_unit is not None
+    assert odu_with_airflow.outdoor_unit.airflow_cfm == 482
+    assert odu_with_airflow.outdoor_unit.as_dict()["airflow_cfm"] == 482
     assert status.indoor_unit is not None
     indoor_unit_data = status.indoor_unit.as_dict()
     assert indoor_unit_data == {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -141,6 +141,20 @@ def test_energy_enabled_usage_metrics_use_api_metric_vocabulary(
     assert energy.is_usage_metric_enabled("unknown") is False
 
 
+def test_energy_usage_metrics_expose_display_labels() -> None:
+    """Expose human-readable labels for sensor names."""
+    assert {metric.value: metric.label for metric in ENERGY_USAGE_METRICS} == {
+        "cooling": "Cooling",
+        "electric_heat": "Electric Heat",
+        "fan_gas": "Fan Gas",
+        "fan": "Fan",
+        "gas": "Gas",
+        "hp_heat": "Heat Pump Heat",
+        "loop_pump": "Loop Pump",
+        "reheat": "Reheat",
+    }
+
+
 def test_status_modes_zone_conditioning_and_serialization(
     system_response: dict[str, Any],
 ) -> None:


### PR DESCRIPTION
## Summary

Adds typed helper APIs for Carrier energy usage and unit runtime status so downstream integrations can consume sensor-ready values without parsing raw GraphQL payloads.

## What Changed

- Added normalized `EnergyPeriod` and `EnergyUsageMetric` enums for stable period and usage metric lookups.
- Added `ENERGY_USAGE_METRIC_LABELS` for human-readable sensor labels keyed by usage metric.
- Added energy helpers for current day/month/year measurements, per-period metric totals, enabled usage metrics, and metric labels.
- Preserved whole-number energy values as `int`, fractional values as `float`, and reject absent or non-finite usage values as `None`.
- Added `StatusUnit` models for indoor and outdoor unit runtime details, including fallback airflow support for Carrier payloads that report `iducfm`.
- Exposed the new energy and status helper types through the public package API.
- Added model and GraphQL tests for energy helper lookups, enabled metric detection, value coercion, and unit runtime status serialization.

## Why

Home Assistant sensor code needs stable, typed access to Carrier energy and runtime status values. Keeping the field mapping and payload traversal in `carrier_api` avoids duplicating Carrier-specific raw keys in downstream integrations and keeps compatibility behavior covered by this package's tests.

## Validation

- `./.venv/bin/pytest`
- `./.venv/bin/mypy`
- `./.venv/bin/prek run --all-files`
