### PR TITLE
Add Carrier entry-level (Smart Thermostat) support

### DIFF
--- a/src/carrier_api/__init__.py
+++ b/src/carrier_api/__init__.py
@@ -12,6 +12,7 @@ from .energy import (
     EnergyPeriod,
     EnergyUsageMetric,
 )
+from .entry_level import EntryLevelSystem, EntryLevelZone
 from .errors import (
     AuthError,
     BaseError,
@@ -46,6 +47,8 @@ __all__ = [
     "EnergyMeasurement",
     "EnergyPeriod",
     "EnergyUsageMetric",
+    "EntryLevelSystem",
+    "EntryLevelZone",
     "FanModes",
     "Profile",
     "Status",

--- a/src/carrier_api/api_connection_graphql.py
+++ b/src/carrier_api/api_connection_graphql.py
@@ -18,6 +18,7 @@ from .api_websocket import ApiWebsocket
 from .config import Config
 from .const import ActivityTypes, FanModes, HeatSourceTypes, SystemModes
 from .energy import Energy
+from .entry_level import EntryLevelSystem
 from .errors import (
     CarrierApiAuthError,
     CarrierApiConnectionError,
@@ -565,6 +566,165 @@ class ApiConnectionGraphql:
             energy = Energy(raw=energy_response["infinityEnergy"])
             systems.append(System(profile=profile, status=status, config=config, energy=energy))
         return systems
+
+    async def get_entry_level_systems(self) -> dict[str, Any]:
+        """Fetch entry-level (Smart Thermostat) systems for the current user.
+
+        These are the non-Infinity Carrier Smart Thermostat devices, exposed by
+        a separate query from ``infinitySystems``.
+
+        Returns:
+            The decoded ``getEntryLevelSystems`` GraphQL response data.
+        """
+        operation_name = "getEntryLevelSystems"
+        query = gql(
+            """
+            query getEntryLevelSystems($username: String!) {
+              entryLevelSystems(username: $username) {
+                serial
+                name
+                location_id
+                model
+                firmware
+                temp_unit_format
+                connection {
+                  isConnected
+                  deviceId
+                }
+                zones {
+                  index
+                  mode
+                  rt
+                  rh
+                  clsp { current min }
+                  htsp { current max }
+                  fan_mode
+                  schedule_enabled
+                  hold_end_time
+                  hold_countdown
+                  stage_status
+                  outside_temp
+                }
+              }
+            }
+            """
+        )
+        variable_values = {"username": self.username}
+        return await self.authed_query(
+            operation_name=operation_name, query=query, variable_values=variable_values
+        )
+
+    async def load_entry_level_data(self) -> list[EntryLevelSystem]:
+        """Load all entry-level systems for the account.
+
+        Returns:
+            A list of entry-level system models for the account.
+        """
+        response = await self.get_entry_level_systems()
+        return [
+            EntryLevelSystem(raw=system_response)
+            for system_response in (response.get("entryLevelSystems") or [])
+        ]
+
+    async def update_entry_level_zone(
+        self,
+        serial: str,
+        index: int = 0,
+        mode: str | None = None,
+        cool_set_point: float | None = None,
+        heat_set_point: float | None = None,
+        schedule_enabled: bool | None = None,
+        hold_end_time: int | None = None,
+        fan_mode: str | None = None,
+    ) -> dict[str, Any]:
+        """Update an entry-level zone's mode, set points, hold, or fan.
+
+        Only the provided fields are sent. Carrier expects the cool and heat set
+        points together, so pass both when changing a set point.
+
+        Args:
+            serial: Serial number of the entry-level system to update.
+            index: Zone index to update (entry-level systems are single-zone).
+            mode: Requested HVAC mode (``cool``/``heat``/``off``/``auto``).
+            cool_set_point: Requested cool set point.
+            heat_set_point: Requested heat set point.
+            schedule_enabled: ``False`` holds the zone, ``True`` resumes the
+                programmed schedule.
+            hold_end_time: Optional Carrier hold-until value.
+            fan_mode: Requested fan mode.
+
+        Returns:
+            The decoded mutation response.
+        """
+        query = gql(
+            """
+            mutation updateEntryLevelZone($input: EntryLevelZoneInput!) {
+              updateEntryLevelZone(input: $input) {
+                success
+              }
+            }
+            """
+        )
+        zone_input: dict[str, Any] = {"serial": serial, "index": index}
+        if mode is not None:
+            zone_input["mode"] = mode
+        if cool_set_point is not None:
+            zone_input["clsp"] = {"current": cool_set_point}
+        if heat_set_point is not None:
+            zone_input["htsp"] = {"current": heat_set_point}
+        if schedule_enabled is not None:
+            zone_input["schedule_enabled"] = schedule_enabled
+        if hold_end_time is not None:
+            zone_input["hold_end_time"] = hold_end_time
+        if fan_mode is not None:
+            zone_input["fan_mode"] = fan_mode
+        _LOGGER.debug("updateEntryLevelZone: %s", zone_input)
+        return await self.authed_query(
+            operation_name="updateEntryLevelZone",
+            query=query,
+            variable_values={"input": zone_input},
+        )
+
+    async def hold_entry_level_zone(
+        self,
+        serial: str,
+        index: int = 0,
+        cool_set_point: float | None = None,
+        heat_set_point: float | None = None,
+        hold_end_time: int | None = None,
+    ) -> dict[str, Any]:
+        """Hold an entry-level zone off its schedule at the given set points.
+
+        Args:
+            serial: Serial number of the entry-level system to update.
+            index: Zone index to update.
+            cool_set_point: Optional cool set point to apply with the hold.
+            heat_set_point: Optional heat set point to apply with the hold.
+            hold_end_time: Optional Carrier hold-until value.
+
+        Returns:
+            The decoded mutation response.
+        """
+        return await self.update_entry_level_zone(
+            serial,
+            index,
+            cool_set_point=cool_set_point,
+            heat_set_point=heat_set_point,
+            schedule_enabled=False,
+            hold_end_time=hold_end_time,
+        )
+
+    async def resume_entry_level_schedule(self, serial: str, index: int = 0) -> dict[str, Any]:
+        """Clear an entry-level zone hold and resume its programmed schedule.
+
+        Args:
+            serial: Serial number of the entry-level system to update.
+            index: Zone index to update.
+
+        Returns:
+            The decoded mutation response.
+        """
+        return await self.update_entry_level_zone(serial, index, schedule_enabled=True)
 
     async def _update_infinity_config(self, variables: dict[str, Any]) -> dict[str, Any]:
         """Run the Carrier system-level configuration mutation.

--- a/src/carrier_api/entry_level.py
+++ b/src/carrier_api/entry_level.py
@@ -1,0 +1,138 @@
+"""Models for Carrier "entry level" (Smart Thermostat) systems and zones.
+
+These cover the non-Infinity Carrier Smart Thermostat line (e.g. TSTATCCEEF-01)
+exposed by the cloud as ``entryLevelSystems``. They are a separate object type
+from Infinity ``System``: single-zone, addressed by serial and zone index, with
+cool/heat set points sent as a pair.
+"""
+
+from typing import Any
+
+from .util import safely_get_json_value
+
+
+class EntryLevelZone:
+    """Runtime state and set points for one entry-level thermostat zone."""
+
+    def __init__(self, raw: dict[str, Any]) -> None:
+        """Build a zone from a Carrier ``entryLevelSystems`` zone payload.
+
+        Args:
+            raw: Raw zone object from the Carrier GraphQL response.
+        """
+        self.raw = raw
+        self.index: int = safely_get_json_value(raw, "index", int)
+        self.mode: str | None = safely_get_json_value(raw, "mode")
+        self.temperature: float | None = safely_get_json_value(raw, "rt", float)
+        self.humidity: int | None = safely_get_json_value(raw, "rh", int)
+        self.cool_set_point: float | None = safely_get_json_value(raw, "clsp.current", float)
+        self.cool_set_point_min: float | None = safely_get_json_value(raw, "clsp.min", float)
+        self.heat_set_point: float | None = safely_get_json_value(raw, "htsp.current", float)
+        self.heat_set_point_max: float | None = safely_get_json_value(raw, "htsp.max", float)
+        self.fan_mode: str | None = safely_get_json_value(raw, "fan_mode")
+        self.schedule_enabled: bool | None = safely_get_json_value(raw, "schedule_enabled")
+        self.hold_end_time: int | None = safely_get_json_value(raw, "hold_end_time", int)
+        self.hold_countdown: int | None = safely_get_json_value(raw, "hold_countdown", int)
+        self.stage_status: str | None = safely_get_json_value(raw, "stage_status")
+        self.outdoor_temperature: float | None = safely_get_json_value(raw, "outside_temp", float)
+
+    @property
+    def on_hold(self) -> bool:
+        """Return whether the zone is held off its programmed schedule.
+
+        Returns:
+            ``True`` when scheduling is disabled (a manual hold is active).
+        """
+        return self.schedule_enabled is False
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dictionary representation of the zone.
+
+        Returns:
+            A dictionary containing sensor values, set points, and hold state.
+        """
+        return {
+            "index": self.index,
+            "mode": self.mode,
+            "temperature": self.temperature,
+            "humidity": self.humidity,
+            "cool_set_point": self.cool_set_point,
+            "heat_set_point": self.heat_set_point,
+            "fan_mode": self.fan_mode,
+            "schedule_enabled": self.schedule_enabled,
+            "hold_end_time": self.hold_end_time,
+            "stage_status": self.stage_status,
+            "outdoor_temperature": self.outdoor_temperature,
+        }
+
+    def __repr__(self) -> str:
+        """Return a developer-readable representation of the zone.
+
+        Returns:
+            The zone dictionary representation converted to a string.
+        """
+        return str(self.as_dict())
+
+    def __str__(self) -> str:
+        """Return a readable string representation of the zone.
+
+        Returns:
+            The zone representation converted to a string.
+        """
+        return str(self.as_dict())
+
+
+class EntryLevelSystem:
+    """A Carrier entry-level (Smart Thermostat) system and its zones."""
+
+    def __init__(self, raw: dict[str, Any]) -> None:
+        """Build a system from a Carrier ``entryLevelSystems`` payload.
+
+        Args:
+            raw: Raw system object from the Carrier GraphQL response.
+        """
+        self.raw = raw
+        self.serial: str = safely_get_json_value(raw, "serial")
+        self.name: str | None = safely_get_json_value(raw, "name")
+        self.model: str | None = safely_get_json_value(raw, "model")
+        self.firmware: str | None = safely_get_json_value(raw, "firmware")
+        self.location_id: str | None = safely_get_json_value(raw, "location_id")
+        self.temperature_unit: str | None = safely_get_json_value(raw, "temp_unit_format")
+        self.is_connected: bool | None = safely_get_json_value(raw, "connection.isConnected")
+        self.device_id: str | None = safely_get_json_value(raw, "connection.deviceId")
+        self.zones: list[EntryLevelZone] = [
+            EntryLevelZone(zone_json) for zone_json in (safely_get_json_value(raw, "zones") or [])
+        ]
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dictionary representation of the system.
+
+        Returns:
+            A dictionary containing system identity, connection, and zone state.
+        """
+        return {
+            "serial": self.serial,
+            "name": self.name,
+            "model": self.model,
+            "firmware": self.firmware,
+            "location_id": self.location_id,
+            "temperature_unit": self.temperature_unit,
+            "is_connected": self.is_connected,
+            "zones": [zone.as_dict() for zone in self.zones],
+        }
+
+    def __repr__(self) -> str:
+        """Return a developer-readable representation of the system.
+
+        Returns:
+            The system dictionary representation converted to a string.
+        """
+        return str(self.as_dict())
+
+    def __str__(self) -> str:
+        """Return a readable string representation of the system.
+
+        Returns:
+            The system representation converted to a string.
+        """
+        return str(self.as_dict())

--- a/tests/test_api_connection_graphql.py
+++ b/tests/test_api_connection_graphql.py
@@ -1203,3 +1203,75 @@ async def test_update_methods_send_reconcile_when_websocket_exists() -> None:
         "variables": zone_config_variables,
     }
     assert websocket.calls == 3
+
+
+@pytest.mark.asyncio
+async def test_get_entry_level_systems_sends_username(connection: SpyConnection) -> None:
+    """Query entry-level systems by account username."""
+    await connection.get_entry_level_systems()
+    assert connection.authed_calls[-1] == (
+        "getEntryLevelSystems",
+        {"username": connection.username},
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_entry_level_zone_builds_input(connection: SpyConnection) -> None:
+    """Send only provided fields, pairing cool and heat set points."""
+    await connection.update_entry_level_zone(
+        "SERIALXXX",
+        0,
+        mode="cool",
+        cool_set_point=74,
+        heat_set_point=62,
+    )
+    operation, variables = connection.authed_calls[-1]
+    assert operation == "updateEntryLevelZone"
+    assert variables == {
+        "input": {
+            "serial": "SERIALXXX",
+            "index": 0,
+            "mode": "cool",
+            "clsp": {"current": 74},
+            "htsp": {"current": 62},
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_hold_entry_level_zone_disables_schedule(connection: SpyConnection) -> None:
+    """Holding a zone disables its schedule and applies the set point."""
+    await connection.hold_entry_level_zone("SERIALXXX", cool_set_point=74)
+    _, variables = connection.authed_calls[-1]
+    assert variables["input"]["schedule_enabled"] is False
+    assert variables["input"]["clsp"] == {"current": 74}
+
+
+@pytest.mark.asyncio
+async def test_resume_entry_level_schedule_enables_schedule(connection: SpyConnection) -> None:
+    """Resuming a zone re-enables its schedule."""
+    await connection.resume_entry_level_schedule("SERIALXXX")
+    _, variables = connection.authed_calls[-1]
+    assert variables["input"] == {
+        "serial": "SERIALXXX",
+        "index": 0,
+        "schedule_enabled": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_load_entry_level_data_parses_systems(
+    connection: SpyConnection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Build EntryLevelSystem models from the query response."""
+
+    async def fake_get_entry_level_systems() -> dict[str, Any]:
+        return {
+            "entryLevelSystems": [{"serial": "SERIALXXX", "zones": [{"index": 0, "mode": "cool"}]}]
+        }
+
+    monkeypatch.setattr(connection, "get_entry_level_systems", fake_get_entry_level_systems)
+    systems = await connection.load_entry_level_data()
+    assert len(systems) == 1
+    assert systems[0].serial == "SERIALXXX"
+    assert systems[0].zones[0].mode == "cool"

--- a/tests/test_entry_level.py
+++ b/tests/test_entry_level.py
@@ -1,0 +1,72 @@
+"""Tests for entry-level (Smart Thermostat) model parsing and serialization."""
+
+from copy import deepcopy
+from typing import Any
+
+from carrier_api import EntryLevelSystem, EntryLevelZone
+
+SAMPLE_SYSTEM: dict[str, Any] = {
+    "serial": "SERIALXXX",
+    "name": "Basement",
+    "location_id": "LOCATIONXXX",
+    "model": "TSTATCCEEF-01",
+    "firmware": "1.0.0",
+    "temp_unit_format": "F",
+    "connection": {"isConnected": True, "deviceId": "DEVICEXXX"},
+    "zones": [
+        {
+            "index": 0,
+            "mode": "cool",
+            "rt": 75,
+            "rh": 52,
+            "clsp": {"current": 77, "min": 60},
+            "htsp": {"current": 62, "max": 90},
+            "fan_mode": "auto",
+            "schedule_enabled": True,
+            "hold_end_time": 0,
+            "hold_countdown": 45,
+            "stage_status": "Idle",
+            "outside_temp": 97,
+        }
+    ],
+}
+
+
+def test_entry_level_system_parsing_and_serialization() -> None:
+    """Parse a system payload and serialize identity, connection, and zones."""
+    system = EntryLevelSystem(SAMPLE_SYSTEM)
+
+    assert system.serial == "SERIALXXX"
+    assert system.name == "Basement"
+    assert system.model == "TSTATCCEEF-01"
+    assert system.is_connected is True
+    assert system.device_id == "DEVICEXXX"
+    assert len(system.zones) == 1
+
+    zone = system.zones[0]
+    assert zone.index == 0
+    assert zone.mode == "cool"
+    assert zone.temperature == 75.0
+    assert zone.humidity == 52
+    assert zone.cool_set_point == 77.0
+    assert zone.heat_set_point == 62.0
+    assert zone.fan_mode == "auto"
+    assert zone.on_hold is False
+
+    assert system.as_dict()["zones"][0]["cool_set_point"] == 77.0
+    assert repr(system) == str(system.as_dict())
+    assert str(zone) == str(zone.as_dict())
+
+
+def test_entry_level_zone_on_hold_when_schedule_disabled() -> None:
+    """Report a hold when the zone's schedule is disabled."""
+    raw = deepcopy(SAMPLE_SYSTEM["zones"][0])
+    raw["schedule_enabled"] = False
+    assert EntryLevelZone(raw).on_hold is True
+
+
+def test_entry_level_system_without_zones() -> None:
+    """Tolerate a system payload that omits zones."""
+    raw = deepcopy(SAMPLE_SYSTEM)
+    del raw["zones"]
+    assert EntryLevelSystem(raw).zones == []


### PR DESCRIPTION
## Summary

Adds support for the non-Infinity Carrier **Smart Thermostat** line (e.g.
`TSTATCCEEF-01` / `TSTATCCEWF-01`). These live on the same Carrier account and
GraphQL endpoint as Infinity systems, but the cloud exposes them as a separate
object type — `entryLevelSystems` — so the existing `infinitySystems`-based
code doesn't see them.

## What's added

- `EntryLevelSystem` / `EntryLevelZone` models (same `raw`-dict +
  `safely_get_json_value` style as the existing models).
- Reads: `get_entry_level_systems()` and `load_entry_level_data()`.
- Write: `update_entry_level_zone()`, plus `hold_entry_level_zone()` and
  `resume_entry_level_schedule()` convenience helpers.
- Package exports and model tests.

## API details (for reference)

Discovered via schema introspection against a live account:

- Read: `entryLevelSystems(username)` → `EntryLevelSystem { serial, name,
  model, connection { isConnected }, zones { index, mode, rt, rh, clsp{current},
  htsp{current}, fan_mode, schedule_enabled, hold_end_time, stage_status, ... } }`
- Write: `updateEntryLevelZone(input: EntryLevelZoneInput!)` — takes `mode`,
  `clsp`/`htsp` (sent together), `schedule_enabled` (false = hold, true = resume
  schedule), `hold_end_time`, `fan_mode`.
- These come back empty under `getUser.locations[].devices`, which is why the
  current discovery path misses them.

## Validation

- Read + write exercised against live hardware (3× `TSTATCCEEF-01`):
  `load_entry_level_data()` returns the systems with parsed set points/mode,
  `update_entry_level_zone()` returns `success`. All four HVAC modes
  (`cool`/`heat`/`off`/`auto`) and hold/resume confirmed on the device.
- Test suite passes on Python 3.14 (the added model tests plus the existing
  suite).

Note: like Infinity, this cloud is eventually consistent — a write is reflected
on the next read cycle rather than immediately.

## Note on the first commit

The branch opens with a small `fix:` commit parenthesizing three
multi-exception `except A, B:` clauses (invalid in Python 3) in `util.py` and
`api_connection_graphql.py` — without it the package doesn't import. Happy to
split that into its own PR if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
