### PR TITLE
Update prek autoupdate workflow

### DIFF
--- a/.github/workflows/prek_autoupdate.yml
+++ b/.github/workflows/prek_autoupdate.yml
@@ -1,49 +1,31 @@
 name: prek Autoupdate
 on:
   schedule:
-    - cron: "0 2 * * 1"
+    - cron: "0 2 * * *"
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: prek-autoupdate-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
-  update-hooks:
-    name: Update prek Hooks
+  prek-autoupdate:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v7
-
-      - name: Install prek
-        uses: taiki-e/install-action@v2
         with:
-          tool: prek
+          persist-credentials: false
 
-      - name: Run prek auto-update
-        id: prek
-        run: |
-          set -euo pipefail
-          body_file="$GITHUB_WORKSPACE/prek-autoupdate-body.md"
-          {
-            echo "Automated update of \`prek\` hooks."
-            echo
-            echo '```text'
-            prek auto-update --cooldown-days 7 2>&1
-            echo '```'
-          } | tee "$body_file"
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
-        id: cpr
+      - name: Update prek hooks
+        id: prek-autoupdate
+        uses: Snuffy2/prek-autoupdate@v2
         with:
-          commit-message: "chore: update prek hooks"
-          title: "Bump prek Hooks"
-          branch: chore/prek-updates
-          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          labels: dependencies
-          delete-branch: true
-          body-path: prek-autoupdate-body.md
-          add-paths: |
-            prek.toml
+          update-day: "1"


### PR DESCRIPTION
## Summary

Adopts the reusable prek autoupdate action for this repository. It runs it on a daily schedule to cleanup stale PRs but only updates once a week..

## What Changed

- Replaced the repository-local prek installation, update, and pull request steps with `Snuffy2/prek-autoupdate@v2`
- Configured hook updates for Mondays through the reusable action `update-day` input
- Added a daily schedule and a `main` branch push trigger
- Added repository-scoped workflow concurrency without canceling an in-progress update
- Disabled persisted checkout credentials

## Why

Centralizing prek update behavior in the reusable action reduces duplicated workflow logic while retaining repository-specific scheduling and permissions.